### PR TITLE
Fix decision terminology in CONFORMANCE.md: require_human → require_approval

### DIFF
--- a/CONFORMANCE.md
+++ b/CONFORMANCE.md
@@ -36,7 +36,7 @@ An adapter is **OGR-conformant** if it:
    altitudes by `guard_id`
    (see [guard-context propagation](specification/provenance-and-context.md#guard-context-propagation));
 3. honors the composed `Verdict` decision — `block` blocks, `allow` allows,
-   `require_human` gates — at its enforcement point;
+   `require_approval` gates — at its enforcement point;
 4. fails closed on `security.*` decisions unless explicitly configured otherwise.
 
 ## Composer conformance
@@ -44,7 +44,7 @@ An adapter is **OGR-conformant** if it:
 A composer (the component that merges multiple detectors' verdicts into one
 decision) is **OGR-conformant** if it implements the rules in
 [composition](specification/composition.md) — including precedence, the
-most-restrictive-wins default, and `require_human` handling.
+most-restrictive-wins default, and `require_approval` handling.
 
 ## Self-certification
 


### PR DESCRIPTION
**Classification: Editorial** (per CONTRIBUTING.md — no wire change)

## Problem

`CONFORMANCE.md` refers to a `require_human` decision in two places (adapter conformance item 3, composer conformance). The decision enum defined in `schema/verdict.schema.json` and used consistently across `specification/verdict.md`, `specification/overview.md`, and `specification/composition.md` is `require_approval`. There is no `require_human` anywhere else in the spec.

An implementer validating against the schema while reading CONFORMANCE.md would find a decision value that does not exist on the wire.

## Change

Replace both occurrences with `require_approval`. No schema, field, or semantics change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)