### PR TITLE
v0.2 proposal: PEP enrollment, event authenticity, and signed approval receipts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,35 @@ version is independent of any implementation's package version.
 - Folded the specification into the namesake repo `openguardrails/openguardrails`
   as the canonical home of the standard. (Previously `openguardrails-spec`.)
 
+## [v0.2] — draft revision (proposal)
+
+One key model closing two `v0.1` trust gaps: unauthenticated events (#7) and
+the forgeable approval flag (#2). Proposed together because approval receipts
+and event authenticity share the same enrollment/key infrastructure.
+
+### Added
+- **Enrollment & approval receipts**
+  (`specification/enrollment-and-receipts.md`,
+  `schema/approval-receipt.schema.json`): normative enrollment outcomes,
+  authenticated event channels, runtime-signed approval receipts bound to
+  canonical payload digests (RFC 8785 JCS, per-kind digest inputs),
+  cross-altitude bindings, and `pre_authorization` (JIT) grants.
+- Runtime conformance role (`CONFORMANCE.md`).
+
+### Changed
+- `ogr-guardcontext` header version `01` → `02`: flags bit 1 is now advisory
+  ("approval receipt attached") and carries no authority by itself; authority
+  lives in the `ogr-receipt` JWS companion header.
+- Wire version `0.1` → `0.2` in schemas (`$id`, `ogr_version`) and examples.
+
+### Breaking — migration
+- Version-`01` guard-context with flags bit 1 set MUST be treated as carrying
+  **no** approval: the bit was forgeable by the propagating party.
+- Adapters that gated on bit 1 must attach and verify `ogr-receipt` and emit
+  version-`02` contexts.
+- Treating an action as approved now requires receipt verification (signature,
+  expiry, scope, recomputed payload digest) for adapter conformance.
+
 ## [v0] — draft
 
 Initial draft of the contract.

--- a/CONFORMANCE.md
+++ b/CONFORMANCE.md
@@ -4,7 +4,7 @@ OGR conformance is intentionally narrow: it is about *speaking the wire*, not
 about detection quality. Quality is measured separately by
 [`openguardrails-bench`](https://github.com/openguardrails/openguardrails-bench).
 
-There are three conformance roles. An implementation may play more than one.
+There are four conformance roles. An implementation may play more than one.
 
 ## Detector conformance
 
@@ -37,7 +37,13 @@ An adapter is **OGR-conformant** if it:
    (see [guard-context propagation](specification/provenance-and-context.md#guard-context-propagation));
 3. honors the composed `Verdict` decision — `block` blocks, `allow` allows,
    `require_approval` gates — at its enforcement point;
-4. fails closed on `security.*` decisions unless explicitly configured otherwise.
+4. fails closed on `security.*` decisions unless explicitly configured otherwise;
+5. enrolls with its runtime before emitting enforcement-relevant events, and
+   emits them only over a channel authenticated with its enrollment credential
+   (see [Enrollment & approval receipts](specification/enrollment-and-receipts.md));
+6. treats an approval as granted **only** after verifying an approval receipt —
+   signature, expiry, scope, and payload-digest binding — and never honors a
+   bare approval flag.
 
 ## Composer conformance
 
@@ -45,6 +51,21 @@ A composer (the component that merges multiple detectors' verdicts into one
 decision) is **OGR-conformant** if it implements the rules in
 [composition](specification/composition.md) — including precedence, the
 most-restrictive-wins default, and `require_approval` handling.
+
+## Runtime conformance
+
+A runtime (the Policy Decision Point) is **OGR-conformant** if it:
+
+1. binds each enrolled PEP's channel identity to the `subject` values that PEP
+   may assert, and rejects events where the two disagree;
+2. accepts events from unenrolled PEPs only as **unverified** — usable for
+   observability, never as the basis for minting receipts or granting
+   enforcement authority;
+3. mints approval receipts only after the approval flow for a
+   `require_approval` decision completes, with bindings and expiry per
+   [Enrollment & approval receipts](specification/enrollment-and-receipts.md);
+4. distributes and rotates its verification keys so PEPs can validate every
+   receipt for its full lifetime (overlapping rotation windows).
 
 ## Self-certification
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Without OGR, securing an agent is an `N × M × L × S` integration problem: eve
 agent, every detector vendor, every LLM protocol, every sandbox wired pairwise.
 OGR collapses it to `N + M + L + S` — integrate once against the contract.
 
-## The five normative components
+## The six normative components
 
 | Component | What it defines | OTel analogue |
 |---|---|---|
@@ -56,6 +56,7 @@ OGR collapses it to `N + M + L + S` — integrate once against the contract.
 | [Provenance](specification/provenance-and-context.md) | Trust/taint labels on every piece of context | — |
 | [guard-context](specification/provenance-and-context.md#guard-context-propagation) | Correlation of one logical action across gateway / hook / sandbox | trace context (W3C `traceparent`) |
 | [composition](specification/composition.md) | How multiple vendors' verdicts combine into one decision | — |
+| [enrollment & receipts](specification/enrollment-and-receipts.md) | How PEPs authenticate to a runtime, and how approvals become verifiable payload-bound artifacts | — |
 
 Risk categories live in the [taxonomy](specification/taxonomy.md) (`safety.*` and
 `security.*`), versioned and swappable — the contract references category IDs but

--- a/schema/approval-receipt.schema.json
+++ b/schema/approval-receipt.schema.json
@@ -1,0 +1,54 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://openguardrails.com/schema/0.2/approval-receipt.schema.json",
+  "title": "ApprovalReceipt",
+  "description": "Claims object of a runtime-signed approval receipt (JWS payload).",
+  "type": "object",
+  "required": ["ogr_version", "receipt_id", "issuer", "scope", "approver", "approved_at", "expires_at"],
+  "additionalProperties": false,
+  "properties": {
+    "ogr_version": { "type": "string", "const": "0.2" },
+    "receipt_id": { "type": "string", "minLength": 1 },
+    "issuer": { "type": "string", "minLength": 1 },
+    "scope": { "enum": ["single_action", "pre_authorization"] },
+    "guard_id": { "type": "string", "minLength": 1 },
+    "session_id": { "type": "string" },
+    "bindings": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": ["kind", "payload_digest"],
+        "additionalProperties": false,
+        "properties": {
+          "kind": { "enum": ["tool_call", "exec", "network", "file", "tool_register", "mcp_connect", "skill_load"] },
+          "payload_digest": { "type": "string", "pattern": "^sha256:[0-9a-f]{64}$" }
+        }
+      }
+    },
+    "constraints": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "session_id": { "type": "string" },
+        "principal": { "type": "string" },
+        "kinds": { "type": "array", "items": { "type": "string" } },
+        "max_uses": { "type": "integer", "minimum": 1 },
+        "match": { "type": "object" }
+      }
+    },
+    "approver": { "type": "string", "minLength": 1 },
+    "approved_at": { "type": "string", "format": "date-time" },
+    "expires_at": { "type": "string", "format": "date-time" }
+  },
+  "allOf": [
+    {
+      "if": { "properties": { "scope": { "const": "single_action" } }, "required": ["scope"] },
+      "then": { "required": ["guard_id", "bindings"] }
+    },
+    {
+      "if": { "properties": { "scope": { "const": "pre_authorization" } }, "required": ["scope"] },
+      "then": { "required": ["constraints"] }
+    }
+  ]
+}

--- a/schema/guard-event.schema.json
+++ b/schema/guard-event.schema.json
@@ -1,13 +1,13 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://openguardrails.com/schema/0.1/guard-event.schema.json",
+  "$id": "https://openguardrails.com/schema/0.2/guard-event.schema.json",
   "title": "GuardEvent",
   "description": "A unit observed at an OGR interception point.",
   "type": "object",
   "required": ["ogr_version", "event_id", "guard_id", "timestamp", "observation_point", "kind", "subject", "payload"],
   "additionalProperties": false,
   "properties": {
-    "ogr_version": { "type": "string", "const": "0.1" },
+    "ogr_version": { "type": "string", "const": "0.2" },
     "event_id": { "type": "string", "minLength": 1 },
     "guard_id": { "type": "string", "minLength": 1 },
     "session_id": { "type": "string" },

--- a/schema/verdict.schema.json
+++ b/schema/verdict.schema.json
@@ -1,13 +1,13 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://openguardrails.com/schema/0.1/verdict.schema.json",
+  "$id": "https://openguardrails.com/schema/0.2/verdict.schema.json",
   "title": "Verdict",
   "description": "A detector's decision about a GuardEvent.",
   "type": "object",
   "required": ["ogr_version", "event_id", "guard_id", "provider", "decision"],
   "additionalProperties": false,
   "properties": {
-    "ogr_version": { "type": "string", "const": "0.1" },
+    "ogr_version": { "type": "string", "const": "0.2" },
     "event_id": { "type": "string", "minLength": 1 },
     "guard_id": { "type": "string", "minLength": 1 },
     "provider": { "type": "string", "minLength": 1 },

--- a/specification/enrollment-and-receipts.md
+++ b/specification/enrollment-and-receipts.md
@@ -1,0 +1,187 @@
+# Enrollment & approval receipts
+
+How a PEP proves who it is, and how an approval becomes something a PEP can
+verify rather than believe. Keywords per RFC 2119.
+
+## Why one mechanism
+
+Two `v0.1` gaps share a root cause:
+
+1. **Unauthenticated events** — `subject.agent_id` is a claim, not an identity.
+   Events can be spoofed by any local process and selectively suppressed by a
+   compromised agent.
+2. **Unverifiable approvals** — guard-context flags bit 1 ("approval already
+   granted") was propagated by the agent: the party OGR defends against could
+   assert its own approval.
+
+Both reduce to the same missing primitive: a key relationship between PEP and
+runtime. Establish it once, at enrollment, and both events and approvals become
+verifiable.
+
+## Roles and keys
+
+| Party | Holds after enrollment | Used for |
+|---|---|---|
+| Runtime (PDP) | its signing keypair(s); registry of enrolled PEPs | signing receipts; authenticating PEP channels |
+| PEP (adapter) | a short-lived PEP credential; the runtime's verification keys, each with a stable `kid` | authenticating its event channel; verifying receipts, including offline |
+
+## Enrollment
+
+How trust is bootstrapped (enrollment tokens, device posture, attestation) is a
+deployment concern and out of scope. The **outcome** is normative. After
+enrollment a PEP MUST hold:
+
+1. a credential binding it to an identity the runtime recognizes on every
+   connection — an mTLS client certificate or equivalent channel credential.
+   Credentials SHOULD be short-lived and renewed automatically;
+2. the runtime's current verification keys.
+
+Rotation: a runtime MUST publish a new verification key before retiring the old
+one, and MUST keep a retired key available until every receipt signed with it
+has expired. PEPs SHOULD refresh verification keys on every reconnect.
+
+## Event authenticity
+
+1. A PEP MUST send events over a channel authenticated with its enrollment
+   credential. mTLS is RECOMMENDED; the contract stays transport-neutral.
+2. A runtime MUST bind the channel identity to the `subject` values that PEP is
+   allowed to assert, and MUST reject events where the two disagree.
+3. A runtime MAY accept events from unenrolled PEPs for observability, but MUST
+   treat them as unverified and MUST NOT mint receipts for them or derive
+   enforcement authority from them.
+4. Store-and-forward: events buffered while the runtime is unreachable SHOULD
+   be signed per batch (JWS, PEP credential) so delayed delivery is
+   tamper-evident.
+
+## Approval receipts
+
+When the effective verdict is `require_approval`, the action suspends until the
+approval flow completes. The result is not a flag — it is a **receipt**: a
+runtime-signed statement of *what* was approved, *by whom*, *until when*.
+
+### Claims
+
+| Claim | Req | Description |
+|---|---|---|
+| `ogr_version` | MUST | `"0.2"`. |
+| `receipt_id` | MUST | Unique id for this receipt. |
+| `issuer` | MUST | Runtime identity; pairs with the JWS `kid`. |
+| `scope` | MUST | `single_action` \| `pre_authorization`. |
+| `guard_id` | MUST for `single_action` | The logical action approved. |
+| `session_id` | SHOULD | Session binding. |
+| `bindings` | MUST for `single_action` | Array of `{ kind, payload_digest }` — one entry per altitude-projection of the approved action the runtime can derive. |
+| `constraints` | MUST for `pre_authorization` | See below. |
+| `approver` | MUST | Principal who approved, e.g. `user:tom`. |
+| `approved_at` | MUST | RFC 3339. |
+| `expires_at` | MUST | RFC 3339. `single_action` expiry SHOULD be minutes. |
+
+The normative JSON Schema is
+[`schema/approval-receipt.schema.json`](../schema/approval-receipt.schema.json).
+
+### Envelope
+
+A receipt is the claims object signed as a JWS (compact serialization) with
+header `{"alg": "...", "kid": "...", "typ": "ogr-receipt+jws"}`. `EdDSA`
+(Ed25519) is the MUST-implement baseline; other algorithms MAY be offered. The
+receipt travels in the `ogr-receipt` companion header next to
+`ogr-guardcontext` (see
+[guard-context propagation](provenance-and-context.md#guard-context-propagation)),
+or by reference where a header is impractical.
+
+### Scopes
+
+**`single_action`** — approves one logical action, identified by `guard_id`
+and bound to the exact payload via `bindings`. This is what satisfying a
+`require_approval` decision produces.
+
+**`pre_authorization`** — a time-boxed, constrained grant minted in advance
+("up to 10 tool calls matching X in the next hour"): the JIT pattern.
+`constraints` fields:
+
+| Field | Description |
+|---|---|
+| `session_id` / `principal` | Binds the grant to a session or principal. |
+| `kinds` | Event kinds the grant covers. |
+| `max_uses` | Use budget. Accounted by the runtime when online; best-effort locally in degraded mode, reconciled on reconnect. |
+| `match` | Opaque, deployment-defined matcher evaluated by the PEP (e.g. compiled policy). A PEP that cannot interpret `match` MUST NOT honor the grant offline. |
+
+### Cross-altitude bindings
+
+The same logical action surfaces with different payloads at different altitudes
+— a `tool_call` at the agent hook becomes an `exec` in the sandbox. A
+`single_action` receipt therefore carries one binding **per projection the
+runtime can derive** at minting time. Verification requires a binding that
+matches the verifying PEP's own event. When none matches — the runtime could
+not project the payload for that altitude — the receipt does not apply, and the
+PEP MUST fall back to asking the runtime (which holds approval state for the
+`guard_id`) or, if unreachable, to its configured unreachable-mode policy.
+
+### Receipt verification
+
+A PEP MUST verify **all** of the following before treating an action as
+approved:
+
+1. the JWS signature is valid against an enrolled runtime verification key
+   (`kid`);
+2. `expires_at` has not passed;
+3. scope match —
+   - `single_action`: the event's `guard_id` equals the receipt's, **and** a
+     `bindings` entry matches the event's `kind` with a `payload_digest` equal
+     to the digest the PEP **recomputes** from the event it is about to
+     enforce;
+   - `pre_authorization`: every present constraint is satisfied.
+
+On any failure the PEP MUST treat the action as unapproved.
+
+Recomputing the digest is the point: approve-X-then-execute-X′ fails closed.
+Replaying a receipt against the same action is harmless — the digest matches
+because the action is identical; against any other action the digest cannot
+match.
+
+## Payload canonicalization
+
+`payload_digest` = `"sha256:" + lowercase-hex(SHA-256(JCS(digest input)))`,
+where JCS is RFC 8785 and the digest input is the kind-specific subset of
+`payload`:
+
+| `kind` | Digest input |
+|---|---|
+| `tool_call` | `{ name, arguments }` |
+| `exec` | `{ argv, cwd }` |
+| `network` | `{ host, port, direction }` |
+| `file` | `{ op, path }` |
+| `tool_register` | `{ name, description, schema }` |
+| `mcp_connect` | `{ server, url }` |
+| `skill_load` | `{ name, source, content_ref }` |
+
+Subsets exclude fields that legitimately differ between observation and
+execution (e.g. `env_keys`) so digests are stable across altitudes for the same
+action. Kinds not listed are not approvable in `v0.2`.
+
+## What the approver sees
+
+The approval UI SHOULD render from the canonical digest input — decoded and
+human-readable — never from an agent-supplied description of the action. An
+agent that can write its own approval prompt can lie in it; the digest input is
+what will actually execute, and it is what the receipt binds.
+
+## Threat model
+
+| Attack | `v0.1` | `v0.2` |
+|---|---|---|
+| Agent sets the "approval granted" bit itself | Succeeds | Fails — no verifiable receipt |
+| Approve X, execute X′ (TOCTOU) | Undetected | Digest recompute fails closed |
+| Receipt replayed against a different action | — | Digest cannot match |
+| Spoofed GuardEvents from a local process | Accepted | Rejected, or marked unverified |
+| Tampering with buffered degraded-mode events | Undetected | Batch signature fails |
+| Selective event suppression | Undetected | Detectable via liveness signals + reconciliation on reconnect |
+
+## Out of scope
+
+- **Approver authentication** (passkeys, biometrics, hardware-backed approval
+  devices) and where approvals are displayed — deployment concerns. The receipt
+  records *that* and *what* the runtime's approval flow approved; it is
+  agnostic to *how* the approver was authenticated.
+- **Key custody** (HSM, secure enclave) for runtime signing keys — recommended,
+  not mandated by the wire.
+- Enrollment bootstrap trust and the transport wire format.

--- a/specification/guard-event.md
+++ b/specification/guard-event.md
@@ -7,7 +7,7 @@ the OGR analogue of an OpenTelemetry span. Keywords per RFC 2119.
 
 | Field | Type | Req | Description |
 |---|---|---|---|
-| `ogr_version` | string | MUST | Spec version, e.g. `"0.1"`. |
+| `ogr_version` | string | MUST | Spec version, e.g. `"0.2"`. |
 | `event_id` | string | MUST | Unique id for this observation. |
 | `guard_id` | string | MUST | Stable across observation points for one logical action. See [guard-context](provenance-and-context.md#guard-context-propagation). |
 | `session_id` | string | SHOULD | Conversation / agent-run id. Enables stateful, multi-turn detection. |
@@ -51,7 +51,7 @@ rug-pulls, malicious skill content) — detectable at load time, before any call
 
 ```json
 {
-  "ogr_version": "0.1",
+  "ogr_version": "0.2",
   "event_id": "evt-9f2",
   "guard_id": "ga-1a2b",
   "session_id": "run-55",

--- a/specification/overview.md
+++ b/specification/overview.md
@@ -23,6 +23,13 @@ enforces.
                  Verdict ◀──────── composition ◀──────────────────────────┘
 ```
 
+Verdicts are only enforceable if the channel carrying them — and the approvals
+that satisfy them — can be trusted.
+[Enrollment & approval receipts](enrollment-and-receipts.md) defines how an
+interception point authenticates to a runtime and how a `require_approval`
+grant becomes a verifiable, payload-bound artifact rather than a propagated
+flag.
+
 ## Three observation altitudes
 
 The same logical action is often observable at more than one point. OGR treats
@@ -62,6 +69,7 @@ ceiling is semantic, fine, and provenance-aware.
 | event & verdict contract | detection mechanism (config rules **or** model/classifier) |
 | provenance & guard-context | detection quality, coverage, latency, freshness |
 | composition meta-policy *mechanism* | which vendors to subscribe to and how to weight them |
+| enrollment & receipt mechanism | approver authentication method and approval UX |
 | risk taxonomy (category IDs) | thresholds, what counts as unsafe for a use case |
 
 A `Verdict` carries a `provider` field precisely so a runtime can attribute,

--- a/specification/provenance-and-context.md
+++ b/specification/provenance-and-context.md
@@ -54,13 +54,29 @@ When an agent hands an action to a sandbox (or a gateway to an agent), it SHOULD
 propagate context out of band, analogous to W3C `traceparent`:
 
 ```
-ogr-guardcontext: 01|<guard_id>|<session_id>|<flags>
+ogr-guardcontext: 02|<guard_id>|<session_id>|<flags>
 ```
 
 (`|`-delimited; fields are opaque and URL-safe so ids may contain `-`.)
 
-- `01` — version.
-- `flags` — bit 0 = "provenance present"; bit 1 = "approval already granted".
+- `02` — version.
+- `flags` — bit 0 = "provenance present"; bit 1 = "approval receipt attached".
+
+Bit 1 is advisory only: it signals that an approval receipt accompanies the
+context, and carries **no authority by itself**. Authority lives in the
+receipt — a runtime-signed, payload-bound artifact defined in
+[Enrollment & approval receipts](enrollment-and-receipts.md) — propagated in a
+companion header:
+
+```
+ogr-receipt: <JWS compact serialization>
+```
+
+A receiver MUST ignore bit 1 unless the accompanying receipt
+[verifies](enrollment-and-receipts.md#receipt-verification). Version-`01`
+contexts with bit 1 set MUST be treated as carrying **no** approval: that bit
+was forgeable by the propagating party, which is the party OGR defends
+against.
 
 A sandbox that receives `ogr-guardcontext` MUST stamp the inherited `guard_id`
 and provenance onto the `exec`/`network`/`file` events it emits. This is what

--- a/specification/verdict.md
+++ b/specification/verdict.md
@@ -33,6 +33,11 @@ verdict per detector and [composes](composition.md) them into a single
 A detector that does not handle an event's `kind`, or finds nothing, MUST return
 `allow` (an explicit abstention), never silence.
 
+How a `require_approval` decision is satisfied downstream — the approval flow,
+the runtime-signed receipt that records the grant, and how enforcement points
+verify it — is specified in
+[Enrollment & approval receipts](enrollment-and-receipts.md).
+
 ### `categories` entry
 
 ```json
@@ -55,7 +60,7 @@ or `security`.
 
 ```json
 {
-  "ogr_version": "0.1",
+  "ogr_version": "0.2",
   "event_id": "evt-9f2",
   "guard_id": "ga-1a2b",
   "provider": "ogr.poc.llm_judge",


### PR DESCRIPTION
**Classification: Normative, breaking** (guard-context header format). Per GOVERNANCE.md this lands as a logged `v0` draft revision — CHANGELOG entry and migration notes included.

Closes #2. Closes #7.

## Rationale

#2 (forgeable approval flag) and #7 (unauthenticated events) share a root cause: there is no key relationship between a PEP and its runtime. This PR establishes that relationship once — at **enrollment** — and derives both fixes from it:

- **Event authenticity**: PEPs send events over channels authenticated with their enrollment credential; runtimes bind channel identity to the `subject` values a PEP may assert and reject mismatches. Unenrolled PEPs may still be observed, but only as *unverified* — no receipts, no enforcement authority.
- **Approval receipts**: satisfying `require_approval` now produces a runtime-signed JWS receipt binding *what* was approved (canonical payload digest), *by whom*, *until when*. The PEP recomputes the digest of the action it is about to enforce — approve-X-execute-X′ (TOCTOU) fails closed. guard-context bit 1 becomes advisory ("receipt attached") and carries no authority by itself.

## What's in the diff

| File | Change |
|---|---|
| `specification/enrollment-and-receipts.md` | **New.** Enrollment outcomes, event authenticity, receipt claims/envelope/scopes, cross-altitude bindings, verification rules, per-kind canonicalization (RFC 8785 JCS), WYSIWYS guidance, threat model. |
| `schema/approval-receipt.schema.json` | **New.** Receipt claims schema (scope-conditional requirements via if/then). |
| `specification/provenance-and-context.md` | guard-context `01` → `02`; bit 1 redefined; `ogr-receipt` companion header; v01-bit-1 MUST be treated as unapproved. |
| `CONFORMANCE.md` | Adapter items 5–6 (enrollment, receipt verification); new **Runtime conformance** role. |
| `CHANGELOG.md` | `[v0.2]` entry with breaking/migration notes. |
| Schemas + examples | Wire version `0.1` → `0.2`. |
| `README.md` / `overview.md` / `verdict.md` | Cross-references; five → six normative components. |

## Design decisions (deviations from the issue sketches)

1. **`session` scope folded into `pre_authorization` constraints.** Issue #2 sketched `single_action | session | pre_authorization`; an unconstrained session scope reopens TOCTOU per action, so session binding is now just a constraint on a pre-authorization grant.
2. **`bindings` is an array, not a single digest.** The same logical action has different payloads per altitude (`tool_call` at the hook vs `exec` in the sandbox). The runtime mints one binding per projection it can derive; a PEP whose event matches no binding falls back to asking the runtime (which holds approval state for the `guard_id`) or to its unreachable-mode policy. This keeps receipts useful offline without trusting upstream verification.
3. **EdDSA (Ed25519) as MUST-implement baseline**, JWS compact envelope, `typ: ogr-receipt+jws` — library-supported everywhere, algorithm-agile via `kid`.
4. **Approver authentication is explicitly out of scope.** The receipt records that the runtime's approval flow completed; *how* the approver was authenticated (passkeys, biometrics, hardware-backed devices such as a phone secure element) is a deployment concern. This keeps the wire stable while approval UX evolves.

## Open questions for review

1. Should receipt claims adopt JWT registered claims (`exp`/`iat` NumericDate) for library interop, instead of OGR-native RFC 3339 fields?
2. `constraints.match` is opaque and deployment-defined — enough for v0.2, or does it need a minimal portable matcher format before v1?
3. Receipt-by-reference transport (for header-size-constrained paths) is mentioned but not specified — defer to transport bindings?
4. Future: dual-signature receipts (runtime + approver-held key co-signing) would let approver devices anchor receipts in hardware without wire changes elsewhere — v0.3 candidate?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
