### PR TITLE
v0.3 draft: findings, reversible redaction, local pre-detection redaction, safety.pii registry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,36 @@ version is independent of any implementation's package version.
 - Folded the specification into the namesake repo `openguardrails/openguardrails`
   as the canonical home of the standard. (Previously `openguardrails-spec`.)
 
+## [v0.3] — draft revision (proposal)
+
+Span-level detection and privacy-preserving deployment: separate *what was
+found* from *what to do*, and let the enforcement point scrub payloads
+before they ever leave the trust boundary.
+
+### Added
+- **`Verdict.findings`** — normalized span-capable detection results
+  (`category`, `path`, `start`/`end`, `score`, `detector`); offsets only,
+  never matched text (`specification/verdict.md`).
+- **Reversible redaction** — `operator` (`replace|mask|hash|encrypt`) and
+  `ref` on `modifications.spans[]` for stable pseudonyms and
+  redact-then-restore round-trips.
+- **Local pre-detection redaction** (`specification/local-redaction.md`):
+  `GuardEvent.content_encoding` (issue #6) + `GuardEvent.redactions`
+  metadata, the placeholder convention, and a **normative redactor
+  contract** (`POST /analyze`, presidio-analyzer-compatible) with a new
+  Redactor conformance role (`CONFORMANCE.md`).
+- **`safety.pii.*` subcategory registry** with hierarchical rollup
+  (`safety.pii.national_id.cn` → `safety.pii.national_id`) and an
+  informative presidio entity mapping (`specification/taxonomy.md`).
+- **Composition of modifications** — union-of-spans rule for `redact`,
+  first-winner rule for whole-payload rewrites
+  (`specification/composition.md`).
+
+### Changed
+- Wire version `0.2` → `0.3` in schemas (`$id`, `ogr_version`) and examples.
+- All new fields are optional: a valid v0.2 object is a valid v0.3 object
+  after the version-string bump.
+
 ## [v0.2] — draft revision (proposal)
 
 One key model closing two `v0.1` trust gaps: unauthenticated events (#7) and

--- a/CONFORMANCE.md
+++ b/CONFORMANCE.md
@@ -43,7 +43,20 @@ An adapter is **OGR-conformant** if it:
    (see [Enrollment & approval receipts](specification/enrollment-and-receipts.md));
 6. treats an approval as granted **only** after verifying an approval receipt —
    signature, expiry, scope, and payload-digest binding — and never honors a
-   bare approval flag.
+   bare approval flag;
+7. when emitting `content_encoding: redacted` (or `hashed`), populates
+   `redactions` for every span it transformed and retains the original
+   locally for verdict enforcement (see
+   [Local redaction](specification/local-redaction.md)).
+
+## Redactor conformance
+
+A local redaction service is **OGR-conformant** if it implements the span
+contract in [Local redaction](specification/local-redaction.md):
+`POST /analyze` accepting `{text, language, score_threshold}` and returning
+`[{entity_type, start, end, score}]`, plus `GET /health`. Any conformant
+redactor container works with any conformant adapter; the adapter — not the
+redactor — applies operators and holds originals.
 
 ## Composer conformance
 

--- a/schema/approval-receipt.schema.json
+++ b/schema/approval-receipt.schema.json
@@ -1,13 +1,13 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://openguardrails.com/schema/0.2/approval-receipt.schema.json",
+  "$id": "https://openguardrails.com/schema/0.3/approval-receipt.schema.json",
   "title": "ApprovalReceipt",
   "description": "Claims object of a runtime-signed approval receipt (JWS payload).",
   "type": "object",
   "required": ["ogr_version", "receipt_id", "issuer", "scope", "approver", "approved_at", "expires_at"],
   "additionalProperties": false,
   "properties": {
-    "ogr_version": { "type": "string", "const": "0.2" },
+    "ogr_version": { "type": "string", "const": "0.3" },
     "receipt_id": { "type": "string", "minLength": 1 },
     "issuer": { "type": "string", "minLength": 1 },
     "scope": { "enum": ["single_action", "pre_authorization"] },

--- a/schema/guard-event.schema.json
+++ b/schema/guard-event.schema.json
@@ -1,13 +1,13 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://openguardrails.com/schema/0.2/guard-event.schema.json",
+  "$id": "https://openguardrails.com/schema/0.3/guard-event.schema.json",
   "title": "GuardEvent",
   "description": "A unit observed at an OGR interception point.",
   "type": "object",
   "required": ["ogr_version", "event_id", "guard_id", "timestamp", "observation_point", "kind", "subject", "payload"],
   "additionalProperties": false,
   "properties": {
-    "ogr_version": { "type": "string", "const": "0.2" },
+    "ogr_version": { "type": "string", "const": "0.3" },
     "event_id": { "type": "string", "minLength": 1 },
     "guard_id": { "type": "string", "minLength": 1 },
     "session_id": { "type": "string" },
@@ -28,6 +28,23 @@
       }
     },
     "payload": { "type": "object" },
+    "content_encoding": { "enum": ["raw", "redacted", "hashed", "metadata_only"], "default": "raw" },
+    "redactions": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["path", "start", "end"],
+        "additionalProperties": false,
+        "properties": {
+          "path":     { "type": "string" },
+          "start":    { "type": "integer", "minimum": 0 },
+          "end":      { "type": "integer", "minimum": 0 },
+          "category": { "type": "string", "pattern": "^(safety|security|x)\\.[a-z0-9_.]+$" },
+          "operator": { "enum": ["replace", "mask", "hash", "encrypt"] },
+          "ref":      { "type": "string" }
+        }
+      }
+    },
     "context_refs": { "type": "array", "items": { "type": "string" } },
     "provenance": {
       "type": "array",

--- a/schema/verdict.schema.json
+++ b/schema/verdict.schema.json
@@ -1,13 +1,13 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://openguardrails.com/schema/0.2/verdict.schema.json",
+  "$id": "https://openguardrails.com/schema/0.3/verdict.schema.json",
   "title": "Verdict",
   "description": "A detector's decision about a GuardEvent.",
   "type": "object",
   "required": ["ogr_version", "event_id", "guard_id", "provider", "decision"],
   "additionalProperties": false,
   "properties": {
-    "ogr_version": { "type": "string", "const": "0.2" },
+    "ogr_version": { "type": "string", "const": "0.3" },
     "event_id": { "type": "string", "minLength": 1 },
     "guard_id": { "type": "string", "minLength": 1 },
     "provider": { "type": "string", "minLength": 1 },
@@ -42,13 +42,31 @@
               "path": { "type": "string" },
               "start": { "type": "integer" },
               "end": { "type": "integer" },
-              "replacement": { "type": "string" }
+              "replacement": { "type": "string" },
+              "operator": { "enum": ["replace", "mask", "hash", "encrypt"], "default": "replace" },
+              "ref": { "type": "string" }
             }
           }
         },
         "payload": { "type": "object" }
       }
     },
-    "evidence": { "type": "array", "items": { "type": "object" } }
+    "evidence": { "type": "array", "items": { "type": "object" } },
+    "findings": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["category"],
+        "additionalProperties": false,
+        "properties": {
+          "category": { "type": "string", "pattern": "^(safety|security|x)\\.[a-z0-9_.]+$" },
+          "path":     { "type": "string" },
+          "start":    { "type": "integer", "minimum": 0 },
+          "end":      { "type": "integer", "minimum": 0 },
+          "score":    { "type": "number", "minimum": 0, "maximum": 1 },
+          "detector": { "type": "string" }
+        }
+      }
+    }
   }
 }

--- a/specification/composition.md
+++ b/specification/composition.md
@@ -63,6 +63,16 @@ block  >  require_approval  >  redact  >  modify  >  allow
 - `short_circuit: true` lets the runtime stop once a `block` is reached, so an
   expensive model provider is skipped when a cheap rule already blocked.
 
+## Composing modifications
+
+When the effective decision is `redact`, the effective `modifications.spans`
+MUST be the **union** of spans from all contributing `redact` verdicts.
+Overlapping spans on the same `path` merge to the covering range; the merged
+span keeps the union of the original spans' finding categories. For `modify`
+with whole-payload rewrites (`payload` present), the winning provider per the
+strategy supplies `modifications`; other proposed rewrites are recorded in
+`evidence` (rewrites do not merge).
+
 ## Attribution
 
 The effective verdict MUST record which providers contributed (`provider` on each

--- a/specification/guard-event.md
+++ b/specification/guard-event.md
@@ -7,7 +7,7 @@ the OGR analogue of an OpenTelemetry span. Keywords per RFC 2119.
 
 | Field | Type | Req | Description |
 |---|---|---|---|
-| `ogr_version` | string | MUST | Spec version, e.g. `"0.2"`. |
+| `ogr_version` | string | MUST | Spec version, e.g. `"0.3"`. |
 | `event_id` | string | MUST | Unique id for this observation. |
 | `guard_id` | string | MUST | Stable across observation points for one logical action. See [guard-context](provenance-and-context.md#guard-context-propagation). |
 | `session_id` | string | SHOULD | Conversation / agent-run id. Enables stateful, multi-turn detection. |
@@ -19,6 +19,8 @@ the OGR analogue of an OpenTelemetry span. Keywords per RFC 2119.
 | `provenance` | array | SHOULD | Trust/taint of the inputs that produced this action. See [Provenance](provenance-and-context.md). |
 | `llm_protocol` | enum \| null | MAY | `openai.chat` \| `openai.responses` \| `anthropic.messages` \| `null`. Set by gateway adapters. |
 | `context_refs` | array | MAY | `event_id`s of related prior events. |
+| `content_encoding` | enum | MAY | `raw` (default) \| `redacted` \| `hashed` \| `metadata_only` — how the payload content was transformed before emission. See [Local redaction](local-redaction.md). |
+| `redactions` | array | MAY | Spans the adapter transformed locally before emission (metadata only, never originals). MUST be populated when `content_encoding` is `redacted`. See [Local redaction](local-redaction.md). |
 
 ### `subject`
 

--- a/specification/local-redaction.md
+++ b/specification/local-redaction.md
@@ -1,0 +1,124 @@
+# Local pre-detection redaction
+
+Sending raw content to a detection runtime is itself a data flow that many
+deployments cannot accept. This document specifies how an adapter scrubs
+the payload **before** the `GuardEvent` leaves the trust boundary — with
+anything from a policy-shipped keyword/regex list up to a locally deployed
+NER or LLM redactor — while keeping remote detection useful. The original
+never leaves the enforcement point. Keywords per RFC 2119.
+
+There are two redaction points in OGR, and they are distinct:
+
+1. **Pre-detection, local** (this document): the adapter transforms the
+   payload before emitting the event.
+2. **Post-verdict enforcement** ([verdict](verdict.md)): the adapter
+   applies `modifications` to what flows onward to the model/tool.
+
+## Flow and trust model
+
+```
+interception point (agent hook / gateway / sandbox)
+  original payload
+    → local redactor(s): policy keyword/regex (in-process)
+                         and/or NER / LLM service (local sidecar)
+    → GuardEvent  { content_encoding: "redacted", redactions: [...] }
+    → runtime detection → Verdict (findings / modifications,
+                                   offsets over the *transported* form)
+  the adapter holds the original + the ref map; it maps verdict spans
+  back to the original when enforcing, and can restore encrypted spans
+  in responses (see operator/ref in the verdict spec).
+```
+
+**Offset rule.** All span offsets — in `redactions`, `findings`, and
+`modifications` — refer to the payload **as transported**, never to a form
+the receiver has not seen.
+
+## `content_encoding`
+
+`raw | redacted | hashed | metadata_only` (default `raw`) declares how the
+payload content was transformed before emission:
+
+| Value | Meaning |
+|---|---|
+| `raw` | Payload content is the original. |
+| `redacted` | Sensitive spans were replaced/masked/hashed/encrypted locally; `redactions` describes them. |
+| `hashed` | Content fields were wholesale replaced by digests. |
+| `metadata_only` | No content at all — only structural metadata (names, sizes, kinds). |
+
+## `redactions`
+
+Detection quality depends on knowing that *something* was there. An event
+with `content_encoding: redacted` MUST carry a `redactions` entry for every
+span the adapter transformed — metadata only, never originals:
+
+```json
+"redactions": [
+  { "path": "payload.text", "start": 40, "end": 76,
+    "category": "safety.pii.credential",
+    "operator": "encrypt", "ref": "r-8f2e" }
+]
+```
+
+**Placeholder convention** (SHOULD): the in-payload replacement text is
+`[PII:<category>:<ref>]`, e.g. `[PII:safety.pii.credential:r-8f2e]` — an
+LLM judge can then still reason "a credential flowed into this command"
+without seeing it.
+
+## Redactor tiers
+
+Two tiers, deliberately asymmetric in cost:
+
+- **Policy-embedded (no service).** Keyword lists and regex/checksum
+  patterns travel in the policy bundle the adapter receives at enrollment
+  (the same channel as degraded-mode hard rules) and run in-process.
+  Adapters SHOULD implement this tier — it is enough to keep credentials
+  and obvious identifiers local, and it works offline.
+- **Span service (local sidecar).** For NER/LLM redaction the adapter
+  calls a local HTTP service implementing the normative contract below.
+  Vendors distribute redaction models as containers implementing this one
+  contract; any conformant redactor works with any conformant adapter.
+
+## Redactor contract (normative)
+
+```
+POST /analyze
+{ "text": "客户手机号：13812345678", "language": "zh", "score_threshold": 0.5 }
+
+200 OK
+[ { "entity_type": "PHONE_NUMBER", "start": 6, "end": 17, "score": 0.92 } ]
+```
+
+- `text` MAY be an array of strings (batch); the response is then an array
+  of result arrays, index-aligned.
+- `entity_type` SHOULD be a taxonomy id; well-known external names (e.g.
+  presidio-analyzer's `US_SSN`, `PERSON`) are acceptable — the **adapter**
+  MUST map them to taxonomy ids before emitting `redactions` (see the
+  mapping in [taxonomy](taxonomy.md)).
+- `GET /health` returns 200 when serving.
+- The redactor only *finds spans*. The adapter applies operators, builds
+  the `ref` map, and retains originals. A redactor MUST NOT be sent
+  content the deployment classifies as non-exportable — it runs inside
+  the trust boundary by definition.
+
+This wire shape is deliberately compatible with presidio-analyzer, so
+existing presidio deployments are usable as OGR redactors unchanged.
+
+## Adapter obligations
+
+An adapter emitting `content_encoding: redacted` (or `hashed`):
+
+1. MUST populate `redactions` for every transformed span;
+2. MUST retain the original payload locally for verdict enforcement and
+   (for `operator: encrypt`) restoration;
+3. MUST apply operators itself — never delegate placeholder generation to
+   the redactor service;
+4. MUST keep `ref` values unique per event and stable across retries of
+   the same event.
+
+## Runtime behavior on reduced content
+
+A runtime receiving `metadata_only` (or `hashed`) content on an event kind
+whose policy requires content inspection SHOULD NOT silently `allow`; it
+SHOULD return `require_approval` with a reason indicating insufficient
+content for the configured policy. (Under discussion — see proposal open
+questions.)

--- a/specification/taxonomy.md
+++ b/specification/taxonomy.md
@@ -41,9 +41,38 @@ System compromise, judged on actions and data flow.
 | `security.supply_chain` | Untrusted package / MCP / skill / model source. |
 | `security.tool_poisoning` | Malicious tool/MCP **definition** (hidden instructions in descriptions/schemas). |
 
+## `safety.pii.*` — subcategory registry
+
+Span-level PII detection needs entity-level ids; without a shared registry,
+masking policy (which is written *per entity type*) cannot interoperate.
+Semantic buckets:
+
+`person_name, address, email, phone_number, national_id, tax_id, passport,
+driver_license, health_id, bank_card, bank_account, ip_address,
+organization, date_of_birth, credential`
+
+Ids refine hierarchically — semantic type first, country/variant after:
+`safety.pii.national_id.cn`, `safety.pii.tax_id.de.vat`. A consumer that
+does not know a refined id MUST treat it as its longest known prefix
+(`safety.pii.national_id`, ultimately `safety.pii`). This **rollup rule**
+lets policy be written once per bucket ("all national ids → redact") with
+global coverage, and lets country-specific detectors ship without registry
+churn.
+
+Mapping from presidio-analyzer entity names (informative): `US_SSN →
+safety.pii.national_id.us`, `US_ITIN → safety.pii.tax_id.us`, `IN_AADHAAR →
+safety.pii.national_id.in`, `PL_PESEL → safety.pii.national_id.pl`,
+`KR_RRN → safety.pii.national_id.kr`, `UK_NHS → safety.pii.health_id.uk`,
+`IT_FISCAL_CODE → safety.pii.tax_id.it`, `CREDIT_CARD →
+safety.pii.bank_card`, `IBAN_CODE → safety.pii.bank_account`,
+`PHONE_NUMBER → safety.pii.phone_number`, `PERSON →
+safety.pii.person_name`, `LOCATION → safety.pii.address`.
+
 ## Conventions
 
 - A detector MUST use the most specific ID it can justify.
+- Hierarchical rollup: a consumer encountering an unknown id MUST fall back
+  to its longest known dotted prefix before treating it as unknown.
 - Unknown/experimental categories MUST be namespaced under
   `x.<vendor>.<name>` and MUST NOT collide with `safety.*` / `security.*`.
 - `score` is a detector-reported `0.0`–`1.0`; it is **not** comparable across

--- a/specification/verdict.md
+++ b/specification/verdict.md
@@ -17,6 +17,7 @@ verdict per detector and [composes](composition.md) them into a single
 | `modifications` | object | MAY | Required only when `decision` is `modify` or `redact`. |
 | `reasons` | array<string> | SHOULD | Human-readable justification. |
 | `evidence` | array<object> | MAY | Structured pointers (spans, matched rule ids, fetched-artifact hashes). |
+| `findings` | array | SHOULD (span detectors) | Normalized detection results — *what was found*, as opposed to `decision`/`modifications` (*what to do*). |
 | `latency_ms` | number | MAY | Detector self-reported latency. |
 | `confidence` | number | MAY | `0.0`–`1.0`. |
 
@@ -47,20 +48,50 @@ verify it — is specified in
 `id` MUST be drawn from the [taxonomy](taxonomy.md). `domain` MUST be `safety`
 or `security`.
 
+### `findings` entry
+
+```json
+{ "category": "safety.pii.national_id.cn", "path": "payload.text",
+  "start": 7, "end": 25, "score": 0.95, "detector": "ogr.patterns" }
+```
+
+- A finding is *what a detector found*; `decision` and `modifications`
+  remain *what to do about it*. Event-level findings (e.g. a malicious
+  command) omit `path`/`start`/`end`.
+- Findings MUST NOT echo the matched text — offsets only. Otherwise every
+  verdict store becomes a copy of the sensitive data it was meant to guard.
+- All offsets refer to the payload **as transported** (after any
+  [local redaction](local-redaction.md)), never to a form the receiver has
+  not seen.
+- When `decision` is `redact`, `modifications.spans` SHOULD be derivable
+  from the span-bearing findings (same `path`/offsets).
+- `categories` remains the rollup (with max scores) of findings and is the
+  field [composition](composition.md) operates on.
+
 ### `modifications`
 
 ```json
 {
   "kind": "redact",
-  "spans": [ { "path": "payload.text", "start": 40, "end": 76, "replacement": "[REDACTED:pii.email]" } ]
+  "spans": [ { "path": "payload.text", "start": 40, "end": 76,
+               "operator": "encrypt", "ref": "r-8f2e",
+               "replacement": "[PII:safety.pii.email:r-8f2e]" } ]
 }
 ```
+
+`operator` (`replace` default \| `mask` \| `hash` \| `encrypt`) says how the
+span is transformed; `hash` supports stable pseudonyms, `encrypt` supports
+restoration. `ref` is an opaque handle, unique within the verdict: a later
+event or verdict using the same `ref` refers to the same original value. Key
+management and the restore operation are implementation-internal; the
+protocol only guarantees `ref` stability. `replacement` carries a
+placeholder, never the original.
 
 ## Example — an LLM detector blocks an injected install command
 
 ```json
 {
-  "ogr_version": "0.2",
+  "ogr_version": "0.3",
   "event_id": "evt-9f2",
   "guard_id": "ga-1a2b",
   "provider": "ogr.poc.llm_judge",


### PR DESCRIPTION
Draft of the v0.3 wire changes: span-level detection and privacy-preserving deployment. The theme is one separation and one relocation — separate *what was found* from *what to do about it*, and let redaction happen **before** content ever leaves the trust boundary.

## Changes

| Area | Change | Issue |
|---|---|---|
| Verdict | `findings[]` — normalized span-capable detection results (`category`, `path`, `start`/`end`, `score`, `detector`); offsets only, never matched text | #9 |
| Verdict | `modifications.spans[]` gains `operator` (`replace\|mask\|hash\|encrypt`) + `ref` for stable pseudonyms and redact-then-restore round-trips | #10 |
| GuardEvent | `content_encoding` formalized + `redactions[]` metadata; placeholder convention `[PII:<category>:<ref>]` | #6 |
| New spec | `specification/local-redaction.md` — pre-detection local redaction: two-tier redactors (policy-embedded regex floor + local span-service sidecar), **normative** redactor contract (`POST /analyze`, presidio-analyzer-compatible), adapter obligations, offset rule | #6 |
| Conformance | New **Redactor conformance** role; adapter obligation 7 (redacted events carry `redactions`, originals stay local) | #6 |
| Taxonomy | `safety.pii.*` semantic-bucket registry with hierarchical rollup (`national_id.cn` → `national_id`); informative presidio entity mapping | #11 |
| Composition | Union-of-spans rule for `redact`; first-winner rule for whole-payload rewrites | #12 |
| Versioning | Wire `0.2` → `0.3` in `$id`/`ogr_version`/examples. Every new field is optional: a valid v0.2 object is a valid v0.3 object after the version bump | — |

## Reference implementation status

The OGR runtime already implements the detector side: span-level findings internally, spec-shaped `modifications` (`{kind, spans:[{path,...}]}`), `safety.pii.*` hierarchical ids with longest-prefix severity rollup, and an NER slot speaking the redactor contract (verified against presidio-analyzer entity names). `GuardEvent.redactions` and the PEP-side local scrubber are next.

## Open questions

1. Should `findings[].detector` be normative, or is Verdict-level `provider` attribution sufficient once a runtime aggregates multiple internal detectors into one verdict?
2. Does `operator: hash` need algorithm/salt disclosure for cross-vendor joinability, or is that an information leak?
3. Runtime behavior on over-redacted events (`metadata_only` where policy needs content) is a SHOULD-`require_approval` in this draft — needs discussion (relates to #6's capability-declaration scope).

🤖 Generated with [Claude Code](https://claude.com/claude-code)