### PR TITLE
v0.4 proposal: adapter degraded mode, actor lineage, and agent-security observability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,39 @@ not implementations. Downstream SDKs and adapters pin a protocol version.
 The format follows [Keep a Changelog](https://keepachangelog.com/). The protocol
 version is independent of any implementation's package version.
 
-## [Unreleased]
+## [v0.4] — draft revision (proposal)
+
+Agent-security observability and degraded-mode operation: keep a PEP safe when
+the runtime is unreachable, attribute multi-agent delegation, and give the
+agent-security threat classes standard IDs.
 
 ### Added
+- **Adapter degraded mode** (`specification/degraded-mode.md`): a PEP-side
+  `on_unreachable` (`block | allow | require_local_approval`) per category-prefix
+  for when the enforcement point cannot reach the runtime — runtime-independent
+  local approval, locally cached hard rules that stay enforced, degraded
+  entry/exit signaling, and tamper-evident buffered-event replay on reconnect.
+  Replaces the blanket fail-closed default in `CONFORMANCE.md` (issue #3).
+- **Actor lineage** — `subject.parent_agent_id` + `subject.delegation_chain` and
+  an `agent_spawn` kind, so multi-agent delegation (unscoped privilege
+  inheritance, confused deputy) is attributable and itself guardable; distinct
+  from the data-lineage provenance already carried (`specification/guard-event.md`,
+  `schema/guard-event.schema.json`, issue #4).
+- **`config_change` kind** — an agent-hook adapter reporting mutation of its own
+  guardrail surface (permissions, hooks, MCP allowlist, skills), semantics a
+  sandbox `file` write loses (`specification/guard-event.md`, issue #5).
+- **Liveness / heartbeat** — a transport-level PEP heartbeat with
+  enrollment-declared cadence and counters, closing the "selective suppression"
+  gap the threat model already referenced
+  (`specification/enrollment-and-receipts.md`, issue #5).
+- **`security.memory_poisoning`** and **`security.resource_exhaustion`** taxonomy
+  IDs — persistent-memory corruption and loop/rate/spend abuse — as neutral
+  standard IDs, with reference-detector coverage recorded as informative rather
+  than an admission gate (`specification/taxonomy.md`, issue #5).
+- **Detector encoding capability** — detectors declare which `content_encoding`
+  values they can judge and MUST abstain otherwise; completes the edge-redaction
+  story and flags a per-encoding benchmark axis as follow-up
+  (`specification/local-redaction.md`, issue #6).
 - **`safety.unsafe_advice`** taxonomy category — a domain-neutral failure mode
   for confident guidance in a high-stakes domain (medical/financial/legal) that
   is harmful, unsupported, or should have deferred/escalated to a human. Domains
@@ -23,6 +53,9 @@ version is independent of any implementation's package version.
   bucket. (`specification/taxonomy.md`)
 
 ### Changed
+- Wire version `0.3` → `0.4` in schemas (`$id`, `ogr_version`) and examples. All
+  new fields and kinds are optional and the taxonomy additions need no schema
+  change: a valid v0.3 object is a valid v0.4 object after the version-string bump.
 - Folded the specification into the namesake repo `openguardrails/openguardrails`
   as the canonical home of the standard. (Previously `openguardrails-spec`.)
 

--- a/CONFORMANCE.md
+++ b/CONFORMANCE.md
@@ -37,7 +37,13 @@ An adapter is **OGR-conformant** if it:
    (see [guard-context propagation](specification/provenance-and-context.md#guard-context-propagation));
 3. honors the composed `Verdict` decision — `block` blocks, `allow` allows,
    `require_approval` gates — at its enforcement point;
-4. fails closed on `security.*` decisions unless explicitly configured otherwise;
+4. when the runtime is unreachable, honors its configured `on_unreachable`
+   policy per category — `block`, `allow`, or `require_local_approval` — rather
+   than a blanket hard block; keeps locally cached hard rules enforced; and
+   signals degraded entry/exit and buffers events for tamper-evident replay on
+   reconnect (see [Adapter degraded mode](specification/degraded-mode.md)).
+   `security.*` defaults to fail-closed, but the deployer MUST be able to choose
+   `require_local_approval`;
 5. enrolls with its runtime before emitting enforcement-relevant events, and
    emits them only over a channel authenticated with its enrollment credential
    (see [Enrollment & approval receipts](specification/enrollment-and-receipts.md));

--- a/schema/approval-receipt.schema.json
+++ b/schema/approval-receipt.schema.json
@@ -1,13 +1,13 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://openguardrails.com/schema/0.3/approval-receipt.schema.json",
+  "$id": "https://openguardrails.com/schema/0.4/approval-receipt.schema.json",
   "title": "ApprovalReceipt",
   "description": "Claims object of a runtime-signed approval receipt (JWS payload).",
   "type": "object",
   "required": ["ogr_version", "receipt_id", "issuer", "scope", "approver", "approved_at", "expires_at"],
   "additionalProperties": false,
   "properties": {
-    "ogr_version": { "type": "string", "const": "0.3" },
+    "ogr_version": { "type": "string", "const": "0.4" },
     "receipt_id": { "type": "string", "minLength": 1 },
     "issuer": { "type": "string", "minLength": 1 },
     "scope": { "enum": ["single_action", "pre_authorization"] },

--- a/schema/guard-event.schema.json
+++ b/schema/guard-event.schema.json
@@ -1,20 +1,20 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://openguardrails.com/schema/0.3/guard-event.schema.json",
+  "$id": "https://openguardrails.com/schema/0.4/guard-event.schema.json",
   "title": "GuardEvent",
   "description": "A unit observed at an OGR interception point.",
   "type": "object",
   "required": ["ogr_version", "event_id", "guard_id", "timestamp", "observation_point", "kind", "subject", "payload"],
   "additionalProperties": false,
   "properties": {
-    "ogr_version": { "type": "string", "const": "0.3" },
+    "ogr_version": { "type": "string", "const": "0.4" },
     "event_id": { "type": "string", "minLength": 1 },
     "guard_id": { "type": "string", "minLength": 1 },
     "session_id": { "type": "string" },
     "timestamp": { "type": "string", "format": "date-time" },
     "observation_point": { "enum": ["gateway", "agent_hook", "sandbox"] },
     "kind": {
-      "enum": ["user_input", "model_output", "tool_register", "mcp_connect", "skill_load", "tool_call", "tool_result", "exec", "network", "file"]
+      "enum": ["user_input", "model_output", "tool_register", "mcp_connect", "skill_load", "tool_call", "tool_result", "exec", "network", "file", "agent_spawn", "config_change"]
     },
     "llm_protocol": { "enum": ["openai.chat", "openai.responses", "anthropic.messages", null] },
     "subject": {
@@ -24,7 +24,9 @@
         "agent_id": { "type": "string" },
         "agent_type": { "type": "string" },
         "principal": { "type": "string" },
-        "sandbox_id": { "type": "string" }
+        "sandbox_id": { "type": "string" },
+        "parent_agent_id": { "type": "string" },
+        "delegation_chain": { "type": "array", "items": { "type": "string" } }
       }
     },
     "payload": { "type": "object" },

--- a/schema/verdict.schema.json
+++ b/schema/verdict.schema.json
@@ -1,13 +1,13 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://openguardrails.com/schema/0.3/verdict.schema.json",
+  "$id": "https://openguardrails.com/schema/0.4/verdict.schema.json",
   "title": "Verdict",
   "description": "A detector's decision about a GuardEvent.",
   "type": "object",
   "required": ["ogr_version", "event_id", "guard_id", "provider", "decision"],
   "additionalProperties": false,
   "properties": {
-    "ogr_version": { "type": "string", "const": "0.3" },
+    "ogr_version": { "type": "string", "const": "0.4" },
     "event_id": { "type": "string", "minLength": 1 },
     "guard_id": { "type": "string", "minLength": 1 },
     "provider": { "type": "string", "minLength": 1 },

--- a/specification/degraded-mode.md
+++ b/specification/degraded-mode.md
@@ -1,0 +1,75 @@
+# Adapter degraded mode (runtime unreachable)
+
+[Composition](composition.md) specifies what a runtime does when *detectors*
+fail (`on_timeout`, `on_all_failed`) — the PDP side. This document specifies the
+PEP side: what a conformant adapter (agent hook / gateway / sandbox) does when it
+cannot reach the runtime at all. Keywords per RFC 2119.
+
+A runtime outage — or an attacker-induced network partition between agent and
+runtime — must not force a binary choice between blocking every unattended agent
+(operational pressure that pushes operators toward fail-open) and silently
+allowing gated actions (the worst outcome). OGR defines a third behavior between
+`block` and `allow`: **degrade to local approval**.
+
+## `on_unreachable`
+
+Configured per risk category (or category prefix), mirroring composition's
+failure vocabulary:
+
+```yaml
+on_unreachable:
+  "security.*":                 require_local_approval   # gate every security action locally
+  "safety.*":                   allow                    # low-severity safety fails open
+  "security.malicious_command": block                    # never runnable without the runtime
+  queue_timeout_action:         block                    # unattended: action after the queue times out
+```
+
+| Value | Meaning while the runtime is unreachable |
+|---|---|
+| `block` | Deny the gated action. |
+| `allow` | Permit the gated action (fail open). |
+| `require_local_approval` | Suspend the action; the human principal approves through a channel that does not depend on runtime availability. |
+
+A category with no entry defaults to `block` for `security.*`; the `safety.*`
+default is the deployer's explicit choice. A blanket hard-`block` default is
+discouraged precisely because it pushes operators toward configuring fail-open —
+the deployer MUST be able to set `require_local_approval` for any prefix.
+
+## Normative requirements
+
+1. **Runtime-independent approval.** `require_local_approval` MUST use an
+   approval channel that does not depend on runtime availability — an in-terminal
+   prompt, an in-session ask, or a local approval device. An approval that would
+   itself require calling the runtime does not satisfy this.
+2. **Local hard rules stay enforced.** Rules cached locally in the PEP —
+   allow/deny lists, hard limits, and the policy-embedded redaction tier
+   ([local redaction](local-redaction.md#redactor-tiers)) — pushed down at
+   [enrollment](enrollment-and-receipts.md#enrollment), MUST remain enforced in
+   degraded mode. Otherwise an attacker who can cut the runtime link downgrades
+   the whole defense to approval fatigue.
+3. **Loud signaling and reconciliation.** Entering and leaving degraded mode
+   MUST emit events, and events buffered while degraded MUST be delivered to the
+   runtime on reconnect — batch-signed per
+   [event authenticity](enrollment-and-receipts.md#event-authenticity) so
+   delayed delivery is tamper-evident. Reconnect delivery, together with the
+   [liveness](enrollment-and-receipts.md#liveness-heartbeat) heartbeat, is what
+   gives the runtime the "this PEP went dark" signal.
+4. **Unattended agents.** A gated action in degraded mode is suspended. Adapters
+   SHOULD support a queue-with-timeout; the timeout action is itself configurable
+   (`queue_timeout_action`) and defaults to `block`.
+
+## Relationship to pre-authorization
+
+A `pre_authorization` receipt
+([enrollment](enrollment-and-receipts.md#scopes)) minted while the runtime was
+reachable MAY satisfy a gated action in degraded mode without a fresh local
+approval, provided the PEP can evaluate its `constraints` offline (`max_uses` is
+best-effort locally, reconciled on reconnect). This is the intended way to keep a
+known-safe unattended workload running through a short outage without either
+fail-open or approval fatigue.
+
+`on_unreachable` (this document, PEP ↔ runtime link) and the runtime's
+`on_all_failed` ([composition](composition.md#failure--latency), runtime ↔
+detectors) are complementary and independent: the first decides what the
+enforcement point does with no runtime; the second decides what a reachable
+runtime does with no working detector.

--- a/specification/enrollment-and-receipts.md
+++ b/specification/enrollment-and-receipts.md
@@ -51,7 +51,30 @@ has expired. PEPs SHOULD refresh verification keys on every reconnect.
    enforcement authority from them.
 4. Store-and-forward: events buffered while the runtime is unreachable SHOULD
    be signed per batch (JWS, PEP credential) so delayed delivery is
-   tamper-evident.
+   tamper-evident (see [degraded mode](degraded-mode.md)).
+
+## Liveness (heartbeat)
+
+Uninstalling or silencing a PEP is the cheapest bypass of an altitude, and a
+runtime cannot otherwise distinguish "agent idle" from "PEP went dark". An
+enrolled PEP SHOULD emit a periodic **heartbeat** over its authenticated
+channel, with the cadence declared at enrollment:
+
+```
+heartbeat: { interval_s: 30, counters: { events_emitted: 1420, degraded: false } }
+```
+
+- A runtime SHOULD alert when a PEP misses heartbeats beyond a tolerance and
+  MUST treat the gap as a **coverage loss**, not as "no risk". Fleet coverage
+  metrics depend on this signal.
+- Heartbeat is a **transport/enrollment-level** signal, not a `GuardEvent`
+  `kind`: it authenticates like any event on the PEP's channel but carries no
+  guarded action.
+- `counters` let the runtime reconcile against delivered events and catch
+  selective suppression (a PEP reporting N emitted while N−k arrived). Combined
+  with reconnect replay of [degraded-mode](degraded-mode.md) buffers, this is
+  what makes the "selective event suppression" row of the threat model
+  detectable.
 
 ## Approval receipts
 
@@ -63,7 +86,7 @@ runtime-signed statement of *what* was approved, *by whom*, *until when*.
 
 | Claim | Req | Description |
 |---|---|---|
-| `ogr_version` | MUST | `"0.2"`. |
+| `ogr_version` | MUST | `"0.4"`. |
 | `receipt_id` | MUST | Unique id for this receipt. |
 | `issuer` | MUST | Runtime identity; pairs with the JWS `kid`. |
 | `scope` | MUST | `single_action` \| `pre_authorization`. |
@@ -114,7 +137,8 @@ runtime can derive** at minting time. Verification requires a binding that
 matches the verifying PEP's own event. When none matches — the runtime could
 not project the payload for that altitude — the receipt does not apply, and the
 PEP MUST fall back to asking the runtime (which holds approval state for the
-`guard_id`) or, if unreachable, to its configured unreachable-mode policy.
+`guard_id`) or, if unreachable, to its configured
+[unreachable-mode policy](degraded-mode.md).
 
 ### Receipt verification
 
@@ -174,7 +198,7 @@ what will actually execute, and it is what the receipt binds.
 | Receipt replayed against a different action | — | Digest cannot match |
 | Spoofed GuardEvents from a local process | Accepted | Rejected, or marked unverified |
 | Tampering with buffered degraded-mode events | Undetected | Batch signature fails |
-| Selective event suppression | Undetected | Detectable via liveness signals + reconciliation on reconnect |
+| Selective event suppression | Undetected | Detectable via [liveness](#liveness-heartbeat) signals + reconciliation on reconnect |
 
 ## Out of scope
 

--- a/specification/guard-event.md
+++ b/specification/guard-event.md
@@ -7,7 +7,7 @@ the OGR analogue of an OpenTelemetry span. Keywords per RFC 2119.
 
 | Field | Type | Req | Description |
 |---|---|---|---|
-| `ogr_version` | string | MUST | Spec version, e.g. `"0.3"`. |
+| `ogr_version` | string | MUST | Spec version, e.g. `"0.4"`. |
 | `event_id` | string | MUST | Unique id for this observation. |
 | `guard_id` | string | MUST | Stable across observation points for one logical action. See [guard-context](provenance-and-context.md#guard-context-propagation). |
 | `session_id` | string | SHOULD | Conversation / agent-run id. Enables stateful, multi-turn detection. |
@@ -24,13 +24,35 @@ the OGR analogue of an OpenTelemetry span. Keywords per RFC 2119.
 
 ### `subject`
 
+Who is acting. `parent_agent_id` and `delegation_chain` carry **actor lineage**
+for multi-agent systems (an agent that spawns sub-agents) — distinct from the
+**data lineage** [provenance](provenance-and-context.md) carries. Per-event
+subjects look legitimate in isolation; only the delegation path exposes an
+inherited privilege or a confused deputy (a low-privilege agent relaying
+instructions to a high-privilege one).
+
+| Field | Req | Description |
+|---|---|---|
+| `agent_id` | MUST | The acting agent. |
+| `agent_type` | SHOULD | e.g. `claude-code.subagent`. |
+| `principal` | SHOULD | The human/service on whose behalf it acts. |
+| `sandbox_id` | MAY | Sandbox the action runs in. |
+| `parent_agent_id` | MAY | The agent that spawned this one; SHOULD be set by adapters that observe spawn. |
+| `delegation_chain` | MAY | Agent ids root-first, from the top-level agent to this one; length 1 for a top-level agent. MAY be maintained by the runtime from `agent_spawn` events instead of carried on every event. |
+
 ```json
-{ "agent_id": "hermes-1", "agent_type": "hermes", "principal": "user:tom", "sandbox_id": "sbx-7" }
+{ "agent_id": "cc-sub-4", "agent_type": "claude-code.subagent", "principal": "user:tom",
+  "sandbox_id": "sbx-7", "parent_agent_id": "cc-main-1",
+  "delegation_chain": ["cc-main-1", "cc-sub-4"] }
 ```
 
 ## Kinds
 
-A runtime MUST accept all kinds; a detector MAY declare which kinds it handles.
+A runtime MUST accept all kinds; a detector MAY declare which kinds it handles. A
+detector MAY also declare which `content_encoding` values it can meaningfully
+judge; one that receives an encoding it did not declare MUST abstain (`allow`
+with a reason) rather than judge blind (see
+[detector encoding capability](local-redaction.md#detector-encoding-capability)).
 
 | `kind` | Emitted when | `payload` shape (informative) |
 |---|---|---|
@@ -44,16 +66,27 @@ A runtime MUST accept all kinds; a detector MAY declare which kinds it handles.
 | `exec` | sandbox runs a process | `{ "argv": [...], "cwd": "...", "env_keys": [...] }` |
 | `network` | sandbox opens a connection | `{ "host": "...", "port": 443, "direction": "egress" }` |
 | `file` | sandbox reads/writes a path | `{ "op": "write", "path": "..." }` |
+| `agent_spawn` | an agent creates/delegates to a sub-agent | `{ "child_agent_id": "...", "child_agent_type": "...", "granted_scopes": [...] }` |
+| `config_change` | the adapter's own guardrail config changes | `{ "target": "permissions\|hooks\|mcp_allowlist\|skills\|other", "path": "...", "diff_ref": "..." }` |
 
 `tool_register`, `mcp_connect`, and `skill_load` exist because the **definition**
 of a tool/MCP/skill is itself an attack surface (description injection,
 rug-pulls, malicious skill content) — detectable at load time, before any call.
 
+`agent_spawn` makes delegation itself a guarded, detectable action — the hook for
+an "inherited scope exceeds task requirement" detector, and the source a runtime
+can build `subject.delegation_chain` from. `config_change` lets an agent-hook
+adapter report mutation of its **own** guardrail surface (settings/permissions,
+hook definitions, MCP allowlists, skill directories) with semantics that a
+sandbox `file` write loses — configuration integrity is a named attack target,
+and editing the agent's own security config is a first move against the
+`agent_hook` altitude.
+
 ## Example — sandbox `exec` of a piped installer
 
 ```json
 {
-  "ogr_version": "0.2",
+  "ogr_version": "0.4",
   "event_id": "evt-9f2",
   "guard_id": "ga-1a2b",
   "session_id": "run-55",

--- a/specification/local-redaction.md
+++ b/specification/local-redaction.md
@@ -115,10 +115,22 @@ An adapter emitting `content_encoding: redacted` (or `hashed`):
 4. MUST keep `ref` values unique per event and stable across retries of
    the same event.
 
+## Detector encoding capability
+
+A detector MAY declare which `content_encoding` values it can meaningfully judge
+(alongside the kinds it handles, [guard-event](guard-event.md#kinds)). A detector
+that receives an encoding it did not declare MUST abstain — return `allow` with a
+reason — rather than run its logic on content it cannot interpret and report a
+misleading score. Runtimes route and [compose](composition.md) accordingly.
+
+This also makes *detection quality under redaction* a first-class, comparable
+dimension: scoring a benchmark corpus per encoding measures exactly what a
+privacy-sensitive deployer cares about (a per-encoding scoring axis is a
+follow-up for the [benchmark](../benchmarks)).
+
 ## Runtime behavior on reduced content
 
 A runtime receiving `metadata_only` (or `hashed`) content on an event kind
 whose policy requires content inspection SHOULD NOT silently `allow`; it
 SHOULD return `require_approval` with a reason indicating insufficient
-content for the configured policy. (Under discussion — see proposal open
-questions.)
+content for the configured policy.

--- a/specification/overview.md
+++ b/specification/overview.md
@@ -28,7 +28,9 @@ that satisfy them — can be trusted.
 [Enrollment & approval receipts](enrollment-and-receipts.md) defines how an
 interception point authenticates to a runtime and how a `require_approval`
 grant becomes a verifiable, payload-bound artifact rather than a propagated
-flag.
+flag. When the runtime is unreachable, [adapter degraded mode](degraded-mode.md)
+keeps the enforcement point safe — degrading to runtime-independent local
+approval rather than failing fully open or fully closed.
 
 ## Three observation altitudes
 

--- a/specification/taxonomy.md
+++ b/specification/taxonomy.md
@@ -41,6 +41,8 @@ System compromise, judged on actions and data flow.
 | `security.sandbox_escape` | Attempt to break out of the sandbox. |
 | `security.supply_chain` | Untrusted package / MCP / skill / model source. |
 | `security.tool_poisoning` | Malicious tool/MCP **definition** (hidden instructions in descriptions/schemas). |
+| `security.memory_poisoning` | Persistent/cross-session corruption of agent memory — instructions implanted in memory that survive across sessions. |
+| `security.resource_exhaustion` | Loop amplification, runaway API spend, action/order spam — abuse judged on action rates and volume. |
 
 ## `safety.pii.*` — subcategory registry
 
@@ -86,6 +88,20 @@ symbols) have no neutral home in the standard and stay under the vendor namespac
 `x.ogr.politics.general`, `x.ogr.politics.sensitive`, `x.ogr.national_symbols`. Per
 the rollup rule below, a consumer that doesn't recognize a refinement treats it as
 its parent (`safety.toxicity.hate` → `safety.toxicity`).
+
+## Reference detector coverage (informative)
+
+An ID is defined by its threat class, **not** by whether any given detector emits
+it — the taxonomy is a neutral vocabulary, and several standard IDs
+(`security.supply_chain`, `security.sandbox_escape`) already have no reference
+emitter. For the two agent-security IDs added in v0.4, the OpenGuardrails
+reference pipeline maps only *partially*: its indirect-injection capability flags
+memory-write payloads (an informative source for `security.memory_poisoning`),
+and its content-safety S9 class covers model resource-consumption loops (an
+informative source for `security.resource_exhaustion`). Neither is a dedicated
+persistent-memory or rate-abuse detector; third-party or future detectors report
+against the same IDs. Reference coverage is a roadmap note, never an admission
+gate for the standard.
 
 ## Conventions
 

--- a/specification/verdict.md
+++ b/specification/verdict.md
@@ -91,7 +91,7 @@ placeholder, never the original.
 
 ```json
 {
-  "ogr_version": "0.3",
+  "ogr_version": "0.4",
   "event_id": "evt-9f2",
   "guard_id": "ga-1a2b",
   "provider": "ogr.poc.llm_judge",


### PR DESCRIPTION
## Summary

v0.4 draft proposal resolving the four open normative issues **#3–#6**, bundled as one versioned proposal per the v0.2 (#8) / v0.3 (#13) precedent. All changes are additive (new optional fields/kinds, new taxonomy IDs) — a valid v0.3 object is a valid v0.4 object after the version-string bump.

## What changed, by issue

| Issue | Change | Key files |
|---|---|---|
| **#3** (P1) `on_unreachable` | New `specification/degraded-mode.md`: `on_unreachable: block \| allow \| require_local_approval` per category-prefix + 4 normative notes (runtime-independent approval, cached hard rules stay enforced, loud signaling + tamper-evident replay, unattended queue-with-timeout). Reworks the criticized blanket fail-closed in `CONFORMANCE.md` item 4 and grounds the previously-dangling "unreachable-mode policy" / "degraded-mode hard rules" references. | `degraded-mode.md` (new), `CONFORMANCE.md`, `overview.md`, `enrollment-and-receipts.md` |
| **#4** delegation | `subject.parent_agent_id` + `subject.delegation_chain` (actor lineage, distinct from data-lineage provenance) and an `agent_spawn` kind. | `guard-event.md`, `schema/guard-event.schema.json` |
| **#5** observability | `config_change` kind; transport-level liveness/heartbeat (closes the threat-model "liveness signals" reference); `security.memory_poisoning` + `security.resource_exhaustion` taxonomy IDs. | `guard-event.md`, `enrollment-and-receipts.md`, `taxonomy.md`, schema |
| **#6** encoding | Detector encoding-capability declaration + MUST-abstain; removes the "under discussion" note; per-encoding benchmark flagged as follow-up. | `guard-event.md`, `local-redaction.md` |

## Design notes

- **Taxonomy neutrality.** `memory_poisoning` / `resource_exhaustion` are added as standard `security.*` IDs regardless of whether the reference pipeline emits them — the taxonomy already contains IDs with no reference emitter (`security.supply_chain`, `security.sandbox_escape`). Reference-detector coverage is recorded as *informative*, never an admission gate.
- **Heartbeat** is specified at the transport/enrollment layer, not as a `GuardEvent` kind.
- **Wire bump 0.3 → 0.4** because #4/#5 touch the JSON schema (new kinds + subject fields); taxonomy additions need no schema change.

## Validation

- All 3 JSON schemas parse; the GuardEvent/Verdict examples and the new `subject` fragment validate against the 0.4 schemas.
- All internal `.md` links + anchors resolve across the touched files.
- No test reads `schema/*.json`, so the version bump does not affect CI. Downstream implementations (`packages/python` pins 0.1; mitmproxy gateway pins 0.3) intentionally keep their pins until they adopt 0.4.

## Follow-ups (not in this PR)

- **Runtime:** persist/route `content_encoding`, add the `on_unreachable` config surface, agent-lineage columns, and heartbeat ingestion.
- **Pipeline:** map injection `persistence_memory` → `security.memory_poisoning` and moderation S9 → `security.resource_exhaustion` so the new IDs have reference emitters.
- **Benchmark:** per-encoding scoring axis.

Closes #3
Closes #4
Closes #5
Addresses #6 (detector encoding capability landed; per-encoding benchmark axis tracked as follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)