### PR TITLE
higress: two bugs 1.4.0 would have shipped, found in the local lab

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,7 @@ htmlcov/
 
 # mitmproxy runtime log
 integrations/gateway/mitmproxy/log
+
+# Higress WASM plugin build output (make build / make push)
+integrations/gateway/higress/plugin.wasm
+integrations/gateway/higress/plugin.tar.gz

--- a/integrations/gateway/higress/README.md
+++ b/integrations/gateway/higress/README.md
@@ -223,6 +223,21 @@ instance identity, which the OGR sensor does not model yet.
 | `redis_username` / `redis_password` | *(empty)* | |
 | `session_ttl_s` | `1800` | matches the runtime's run-pointer idle TTL |
 
+⚠️ **`principal_header` and `principal_group_header` are only as trustworthy as
+the edge that writes them.** The plugin reports whatever arrives on them. Measured
+on the lab gateway: a request authenticating as consumer `carol` that carried its
+own `x-mse-consumer: root-admin` and `x-mse-consumer-group: platform-admins` was
+reported as exactly that — `key-auth` (priority 310, so it does run first) sets
+the headers when they are absent but did not overwrite the caller's.
+
+That is one hole with two different sizes. A forged `principal` misattributes the
+audit trail; a forged group changes WHICH POLICY SET applies, because the platform
+maps the group to a workspace — so a caller who picks their own group picks their
+own guardrails. Strip `x-mse-consumer` and `x-mse-consumer-group` from client
+requests at the edge, before AUTHN, or point these two keys at headers no client
+can reach. Verify it on your own deployment rather than assuming your auth plugin
+does it; ours did not.
+
 ⚠️ **There is no `redact` switch.** Whether to redact is the RUNTIME's decision,
 carried by the verdict (`decision: redact` plus `modifications.spans`). A gateway
 that could turn it off locally would be a second place policy lives — and the

--- a/integrations/gateway/higress/events.go
+++ b/integrations/gateway/higress/events.go
@@ -28,7 +28,10 @@ const (
 	sensorClass      = "proxy"
 	llmProtocol      = "openai.chat"
 	observationPoint = "conversation"
-	pluginVersion    = "1.2.0"
+	// Reported in the heartbeat, so it is how a deployment learns which build is
+	// in the VM. Kept honest by TestPluginVersionMatchesTheVERSIONFile — 1.3.0
+	// and 1.4.0 both shipped while this still said 1.2.0.
+	pluginVersion = "1.4.0"
 
 	maxTranscriptEntries = 64
 	maxEntryText         = 32768

--- a/integrations/gateway/higress/heartbeat.go
+++ b/integrations/gateway/higress/heartbeat.go
@@ -145,7 +145,7 @@ func sendHeartbeat(cfg *Config) {
 		return
 	}
 	// ⚠️ Its OWN budget, not the PDP's. `timeout_ms` is tuned for a caller waiting
-	// on a verdict — 1s by default — and a beat is nobody's latency: sharing that
+	// on a verdict — 5s by default — and a beat is nobody's latency: sharing that
 	// budget just turned healthy heartbeats into 504s whenever the runtime was
 	// briefly busy, i.e. exactly when liveness matters most.
 	if err := cfg.client.Post(pathHeartbeat, ogrHeaders(*cfg), payload,

--- a/integrations/gateway/higress/heartbeat_test.go
+++ b/integrations/gateway/higress/heartbeat_test.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// The heartbeat carries the plugin's version, and that is how an operator learns
+// WHICH build is in the VM. A stale constant is worse than no version at all: it
+// names a build that is not running, so the one signal that could have caught a
+// bad rollout confirms the wrong thing instead.
+//
+// Nothing tied this constant to the VERSION file before, and it drifted through
+// two releases — 1.3.0 and 1.4.0 both shipped while it still said 1.2.0.
+func TestPluginVersionMatchesTheVERSIONFile(t *testing.T) {
+	raw, err := os.ReadFile("VERSION")
+	if err != nil {
+		t.Fatalf("reading VERSION: %v", err)
+	}
+	want := strings.TrimSpace(string(raw))
+	if pluginVersion != want {
+		t.Fatalf("pluginVersion = %q but VERSION says %q: the heartbeat would report the wrong build",
+			pluginVersion, want)
+	}
+}

--- a/integrations/gateway/higress/main.go
+++ b/integrations/gateway/higress/main.go
@@ -523,6 +523,18 @@ func onStreamingResponseBody(ctx wrapper.HttpContext, cfg Config, chunk []byte, 
 	if !ok || rs == nil {
 		return chunk
 	}
+	// ⚠️ A refusal is OURS, not the model's. `answer` ends the request with a
+	// locally generated body, and that body still reaches this hook — so without
+	// this the plugin derives a `model_output` from its own refusal text and
+	// ingests it. Two costs, both bad for a thing whose output is evidence: the
+	// audit trail gains a record of something no model ever said, and the runtime
+	// evaluates on ingest, so the refusal is judged by the guardrails that
+	// produced it. `onResponseHeaders` and `onResponseBody` have always checked
+	// this; the streaming hook was the hole, and it swallowed BOTH response
+	// shapes, because a locally generated JSON body arrives here too.
+	if ctx.GetBoolContext(ctxAnswered, false) {
+		return chunk
+	}
 	sp, _ := ctx.GetContext(ctxStream).(*streamProcessor)
 	if sp == nil {
 		sp = newStreamProcessor(rs.session.Mapping, ctx.GetBoolContext(ctxStreaming, true))


### PR DESCRIPTION
Found while smoke-testing 1.4.0 against a local Higress before tagging. The
1.4.0 feature itself (`subject.principal_group`) is fine — it was verified end to
end, on both the `/evaluate` and `/ingest` paths. These are two things sitting
next to it that would have shipped.

## A refusal was being reported as the model's output

Every enforced block ingested a `model_output` event whose text was the plugin's
own refusal, in both response shapes:

```
kind=model_output  text="...refused by the organization's AI usage policy"
```

`onResponseHeaders` and `onResponseBody` have always checked `ctxAnswered`;
`onStreamingResponseBody` never did, and a locally generated body reaches that
hook for both shapes.

The cost is not a stray event. The audit trail was gaining a record of something
no model ever said, attributed to the session, and the runtime evaluates on
ingest — so the refusal was judged by the guardrails that produced it.

## The heartbeat named a build that was not running

`pluginVersion` still said `1.2.0`, so 1.3.0 and 1.4.0 would both have reported
themselves as 1.2.0 in `sensor.version`. Nothing tied the constant to `VERSION`,
which is how it drifted through two releases. `TestPluginVersionMatchesTheVERSIONFile`
now reads the same file the release workflow validates the tag against.

## Also

- **README**: `principal_header` / `principal_group_header` name headers the
  plugin TRUSTS. On the lab gateway a request authenticating as consumer `carol`
  and carrying its own `x-mse-consumer: root-admin` /
  `x-mse-consumer-group: platform-admins` was reported as exactly that —
  `key-auth` sets both when absent but does not overwrite the caller's. A forged
  principal misattributes the audit trail; a forged group changes which policy
  set applies. Now documented as an edge responsibility, with the advice to
  verify rather than assume.
- `heartbeat.go` comment still quoted the pre-7172dd1 1s budget.
- `plugin.wasm` / `plugin.tar.gz` were never gitignored.

## Verification

`gofmt` / `go vet` / 41 tests / `GOOS=wasip1 GOARCH=wasm` build, all green
locally with Go 1.24.13 (matching the workflow's `1.24`).

Re-verified against a live Higress with a stub runtime after the fix. Both the
fixes and — more importantly — the regressions on the hook the guard sits on:

| | |
|---|---|
| block, buffered + streaming | one `user_input` to `/evaluate`, no `model_output` |
| heartbeat | `sensor.version` = `1.4.0` |
| allow | real `model_output` still reported |
| redact, buffered | upstream saw `${OGR_EMAIL_1}`, client got the plaintext back |
| redact, **real SSE upstream** | reply split mid-sentence still reassembled, still reported, placeholders still restored |

🤖 Generated with [Claude Code](https://claude.com/claude-code)