### PR TITLE
Local secrets redaction reaches six harnesses, in two shapes

### DIFF
--- a/integrations/agent/README.md
+++ b/integrations/agent/README.md
@@ -7,13 +7,40 @@ harness exposes the model call, the plugin sends the paired
 about to execute (hook-based hosts), the plugin sends the canonical
 `step/response` for what it actually holds — each README states its vantage.
 
-| Target | Source |
-|---|---|
-| Claude Code | [`claude-code/`](claude-code/) |
-| Codex | [`codex/`](codex/) |
-| DeepSeek Harness (`dsh`) | [`dsh/`](dsh/) — the reference agent-direct integration |
-| Hermes | [`hermes/`](hermes/) |
-| LangGraph | [`langgraph/`](langgraph/) |
-| litellm | [`litellm/`](litellm/) |
-| OpenClaw | [`openclaw/`](openclaw/) |
-| opencode | [`opencode/`](opencode/) |
+| Target | Source | Local secrets redaction |
+|---|---|---|
+| Claude Code | [`claude-code/`](claude-code/) | via [`ogr-local`](ogr-local/) — hooks are separate processes |
+| Codex | [`codex/`](codex/) | via [`ogr-local`](ogr-local/) — the host is Rust |
+| DeepSeek Harness (`dsh`) | [`dsh/`](dsh/) — the reference agent-direct integration | in-process |
+| Hermes | [`hermes/`](hermes/) | in-process |
+| LangGraph | [`langgraph/`](langgraph/) | — |
+| litellm | [`litellm/`](litellm/) | — |
+| OpenClaw | [`openclaw/`](openclaw/) | in-process |
+| opencode | [`opencode/`](opencode/) | in-process |
+
+Two shared libraries sit under these: [`local-redaction/`](local-redaction/)
+(the reference `mask()`/`restore()`, the served-ruleset loader and the
+in-process HTTP interceptor, beside the conformance corpus) and
+[`ogr-local/`](ogr-local/) (the same masking behind a loopback proxy).
+
+## Where the mask goes, and why it differs
+
+**Six harnesses, two shapes.** Local secrets redaction
+([OGR 1.4](../../specification/local-redaction.md)) replaces every credential
+in the outbound model request with `${OGR_SECRET_n}` on the host, and restores
+it into the reply's tool-call arguments after judgement. *Where* that happens
+is decided by one question: **can code run inside the agent's own process?**
+
+- **In-process (hermes, opencode, openclaw, dsh)** — the plugin installs an
+  interceptor on the process's HTTP client. It covers the system prompt and
+  tool schemas as well as the messages, needs no port, no lifecycle and no
+  base-URL change, and cannot outlive the harness. **Always prefer this.**
+- **A loopback proxy (Claude Code, Codex)** — their hooks are separate
+  processes, and Codex's host is not even JavaScript, so there is no seam
+  inside the agent to install anything on. [`ogr-local`](ogr-local/) sits in
+  front instead, reached by a base URL the operator sets once.
+
+⚠️ The two are not interchangeable, and the proxy is strictly the weaker
+position: it is a second process that has to be running, and if it is down the
+harness cannot reach its provider at all. Nothing that can host an in-process
+plugin should be wired through it.

--- a/integrations/agent/claude-code/README.md
+++ b/integrations/agent/claude-code/README.md
@@ -102,6 +102,60 @@ All via environment variables:
 | `OGR_AGENT_WORKSPACE` | `""` | `agent_workspace` claim; empty = the API key's workspace |
 | `OGR_AGENT_USER` | `""` | `agent_user` claim |
 
+## Local secrets redaction: the value never leaves this machine
+
+Credentials in your prompts, files and tool output are replaced with
+`${OGR_SECRET_n}` **before the request leaves your machine**. Anthropic is
+given the placeholder; the real value goes back into the tool's arguments
+locally, after judgement, so the tool still runs. The ruleset is your
+organization's, served by the runtime — nothing here ships patterns.
+
+⚠️ **It needs a small proxy, and that is not a design preference.** The other
+OGR integrations mask inside the agent's own process with a `fetch`
+interceptor. Claude Code runs its hooks as separate **processes**, so there
+is no seam inside the agent to install one on. The next vantage down is a
+socket in front of it.
+
+```sh
+npm i -g @openguardrails/ogr-local
+```
+
+Then point Claude Code at it, in `~/.claude/settings.json`:
+
+```json
+{
+  "env": {
+    "ANTHROPIC_BASE_URL": "http://127.0.0.1:8787/https/api.anthropic.com"
+  }
+}
+```
+
+That is the only manual step. The plugin's `SessionStart` hook starts the
+daemon (idempotently — the port is the lock), and **checks that line**: if
+the proxy is up but `ANTHROPIC_BASE_URL` does not point at it, it says so on
+every session start rather than letting a session look protected while
+nothing is masked. A hook is a child process and cannot set the variable
+itself.
+
+Turn it off with `OGR_LOCAL_REDACTION=0`; move the port with
+`OGR_LOCAL_PORT`. See [`@openguardrails/ogr-local`](../ogr-local) for what
+the proxy does and does not do — in particular, it holds no credential, is
+not an open proxy, and offers no way to turn a token back into a secret.
+
+### What the runtime is told
+
+The PreToolUse hook reads Claude Code's **transcript**, which holds the value
+in the clear — the proxy restored it on the way back. So before reporting, the
+hook asks the proxy to put the tokens back, and attaches the step's
+`redaction`: the ruleset id and the tokens minted, never a value. Without
+that the runtime would be handed a secret the provider never saw and would
+correctly raise a leak that did not happen.
+
+**With no proxy running, the event goes as built and claims nothing.** That
+is deliberate: nothing masked the step, so nothing may say it was masked —
+the runtime's own detector is the one witness left, and a `redaction` field
+there would tell it to treat a real leak as a miss.
+
 ## Honest limits: the fragment vantage
 
 A Claude Code hook never holds the model call — it holds **one tool call about

--- a/integrations/agent/claude-code/hooks/hooks.json
+++ b/integrations/agent/claude-code/hooks/hooks.json
@@ -1,5 +1,16 @@
 {
   "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/ogr-session-start.mjs\"",
+            "timeout": 20
+          }
+        ]
+      }
+    ],
     "PreToolUse": [
       {
         "matcher": "Bash|Read|Edit|Write|WebFetch|mcp__.*",

--- a/integrations/agent/claude-code/hooks/ogr-hook.mjs
+++ b/integrations/agent/claude-code/hooks/ogr-hook.mjs
@@ -153,7 +153,7 @@ function assistantTurnOf(transcriptPath, toolUseId, toolName, toolInput) {
  * row rather than minting a second and reporting the old build as dark — so
  * every replica overwrites the others' version.
  */
-const INTEGRATION = "ogr-claude-code/1.0.0"
+const INTEGRATION = "ogr-claude-code/2.0.0"
 
 // --- GuardEvent → /v1/evaluate → Verdict --------------------------------------
 
@@ -193,6 +193,52 @@ function buildEvent(input) {
     // trimmed history. A grouping hint only — never authorization, ordering or
     // policy selection (guard-event.md § session_hint).
     ...(input.session_id ? { session_hint: String(input.session_id) } : {}),
+  }
+}
+
+/** Where the local masking proxy listens, when one is running (`ogr-local`). */
+const LOCAL_PORT = Number(process.env.OGR_LOCAL_PORT || 8787)
+
+/**
+ * The event, with every secret the proxy masked on the way out replaced by
+ * the SAME `${OGR_SECRET_n}` the model provider was given (OGR 1.4).
+ *
+ * ⚠️⚠️ **THE HOOK'S VANTAGE IS THE HARNESS'S TRANSCRIPT, WHICH IS THE
+ * CLEARTEXT COPY.** The proxy masks the request on its way to the provider
+ * and restores the reply's tool arguments on the way back, so what Claude
+ * Code holds — and what this hook reads — is the real credential. Sending
+ * that straight on would hand the runtime a secret the provider never saw,
+ * and the runtime would correctly raise it as a leak that did not happen.
+ * D6 in one line: the OGR client is an egress too.
+ *
+ * ⚠️ `mask` on the proxy is `maskKnown`, so it can only REUSE tokens the
+ * request half minted; it never allocates a new one. A token this event
+ * invented would name nothing and restore to nothing.
+ *
+ * Never throws and never delays a decision beyond its own short budget: a
+ * proxy that is not running means no local redaction, which is the state
+ * every deployment was in before this existed.
+ */
+async function sealed(event) {
+  try {
+    const res = await fetch(`http://127.0.0.1:${LOCAL_PORT}/__ogr/mask`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ value: event.payload, ...(event.session_hint ? { session: event.session_hint } : {}) }),
+      signal: AbortSignal.timeout(1500),
+    })
+    if (!res.ok) return event
+    const body = await res.json()
+    return {
+      ...event,
+      ...(body.value ? { payload: body.value } : {}),
+      ...(body.redaction ? { redaction: body.redaction } : {}),
+    }
+  } catch {
+    // No proxy, or it did not answer in time. The event goes as built —
+    // which is the honest thing: nothing masked it, so nothing should claim
+    // it was masked, and the runtime's own detector is the one witness left.
+    return event
   }
 }
 
@@ -255,7 +301,7 @@ async function main() {
   }
   if (!input.tool_name) emitAllow() // nothing held → nothing to judge
 
-  const verdict = await evaluate(buildEvent(input))
+  const verdict = await evaluate(await sealed(buildEvent(input)))
   if (!verdict) emitFailMode("runtime unavailable")
 
   if (verdict.decision === "block") emitDeny(reasonOf(verdict))

--- a/integrations/agent/claude-code/hooks/ogr-session-start.mjs
+++ b/integrations/agent/claude-code/hooks/ogr-session-start.mjs
@@ -1,0 +1,90 @@
+#!/usr/bin/env node
+/**
+ * OpenGuardrails — Claude Code SessionStart hook: bring up the local masking
+ * proxy, and say plainly whether Claude Code is actually pointed at it.
+ *
+ * ⚠️⚠️ **WHY A PROXY HERE AT ALL, WHEN FOUR OTHER HARNESSES NEED NONE.**
+ * hermes, opencode, openclaw and dsh load a plugin INSIDE the agent's
+ * process, so their mask is an in-process `fetch` interceptor: no port, no
+ * lifecycle, no base URL to change, and nothing left running when the
+ * harness exits. Claude Code runs its hooks as separate PROCESSES — this
+ * file is one — so there is no seam inside the agent to install anything on.
+ * The next vantage down is a socket in front of it. That is the whole
+ * reason, and it is why nothing here should ever be copied into a harness
+ * that has a real plugin.
+ *
+ * ⚠️ **THIS HOOK CANNOT SET `ANTHROPIC_BASE_URL` AND MUST NOT PRETEND TO.**
+ * A hook is a child process; exporting a variable there reaches nothing.
+ * Claude Code reads its own environment at startup, from `settings.json`'s
+ * `env` block, which is a file the operator owns. So the hook does the two
+ * things it CAN do — start the daemon, and check whether the variable points
+ * at it — and reports the gap loudly rather than leaving a session that
+ * looks protected and is not.
+ *
+ * Never fails the session. A masking proxy that could not start is a reason
+ * to work unprotected and know it, never a reason to be unable to work.
+ */
+import { execFileSync } from "node:child_process"
+
+const PORT = Number(process.env.OGR_LOCAL_PORT || 8787)
+const UPSTREAM = process.env.OGR_LOCAL_UPSTREAM || "https://api.anthropic.com"
+const EXPECTED = `http://127.0.0.1:${PORT}/https/${new URL(UPSTREAM).host}${new URL(UPSTREAM).pathname.replace(/\/$/, "")}`
+
+const say = (message) => process.stderr.write(`[OpenGuardrails] ${message}\n`)
+
+/** The `ogr-local` entry point: an explicit path, else the one on PATH. */
+function binary() {
+  return process.env.OGR_LOCAL_BIN || "ogr-local"
+}
+
+async function listening() {
+  try {
+    const res = await fetch(`http://127.0.0.1:${PORT}/__ogr/status`, {
+      signal: AbortSignal.timeout(700),
+    })
+    return res.ok ? await res.json() : null
+  } catch {
+    return null
+  }
+}
+
+async function main() {
+  if (process.env.OGR_LOCAL_REDACTION === "0" || process.env.OGR_LOCAL_REDACTION === "off") return
+  if (!process.env.OGR_API_KEY) return // the integration is off; nothing to say
+
+  let status = await listening()
+  if (!status) {
+    try {
+      // `ensure` is idempotent and returns as soon as the daemon answers, so
+      // a `--resume` storm cannot start a second one: the port is the lock.
+      execFileSync(binary(), ["ensure", "--port", String(PORT)], {
+        stdio: ["ignore", "ignore", "inherit"],
+        timeout: 15_000,
+      })
+    } catch {
+      say(
+        `could not start the local masking proxy (${binary()}). Install it with `
+        + "`npm i -g @openguardrails/ogr-local`, or set OGR_LOCAL_REDACTION=0 to stop this message. "
+        + "Secrets in your prompts will reach the model provider.",
+      )
+      return
+    }
+    status = await listening()
+  }
+  if (!status) return
+
+  const configured = (process.env.ANTHROPIC_BASE_URL || "").replace(/\/+$/, "")
+  if (configured !== EXPECTED) {
+    // The one failure that would otherwise be silent: the daemon is up, so
+    // every status check looks healthy, while Claude Code talks straight to
+    // the provider and nothing is masked.
+    say(
+      "the local masking proxy is running but Claude Code is not pointed at it — nothing is being masked. "
+      + `Add this to your settings.json and restart:\n    "env": { "ANTHROPIC_BASE_URL": "${EXPECTED}" }`,
+    )
+    return
+  }
+  say(`local secrets redaction active — ruleset ${status.ruleset || "(none yet)"}`)
+}
+
+main().catch(() => {})

--- a/integrations/agent/claude-code/package.json
+++ b/integrations/agent/claude-code/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@openguardrails/instrumentation-claude-code",
   "private": true,
-  "version": "1.0.0",
-  "description": "OpenGuardrails (OGR) v0.8 enforcement for Claude Code — a PreToolUse hook that evaluates each held tool call against an OGR runtime and denies on block, even in bypass mode. Zero dependencies; the runtime decides.",
+  "version": "2.0.0",
+  "description": "OpenGuardrails (OGR) v1.0 enforcement for Claude Code — a PreToolUse hook that evaluates each held tool call against an OGR runtime and denies on block, even in bypass mode, plus local secrets redaction through a loopback masking proxy so credentials never reach the model provider. The runtime decides.",
   "license": "Apache-2.0",
   "type": "module",
   "homepage": "https://openguardrails.com/docs/integrations/agent/claude-code/",

--- a/integrations/agent/claude-code/test/smoke.mjs
+++ b/integrations/agent/claude-code/test/smoke.mjs
@@ -28,11 +28,12 @@ const EVENT_KEYS = [
 
 // The schema has three optional fields — `integration`, `connection`,
 // `session_hint`. This hook sends two: `integration` (2026-08-17), the
-// reporter's own "name/version", and `session_hint`, the host's `session_id`
-// for the conversation. `connection` is a GATEWAY's field and deliberately
+// reporter's own "name/version"; `session_hint`, the host's `session_id`
+// for the conversation; and `redaction` (OGR 1.4), what the local masking
+// proxy replaced before the request left this machine. `connection` is a GATEWAY's field and deliberately
 // stays out of the allowlist, so a stray copy here would fail loudly. An
 // ALLOWLIST, not a relaxation — an unknown key is still a violation.
-const OPTIONAL_EVENT_KEYS = ["integration", "session_hint"]
+const OPTIONAL_EVENT_KEYS = ["integration", "session_hint", "redaction"]
 
 function validateEvent(ev) {
   const errs = []
@@ -52,7 +53,7 @@ function validateEvent(ev) {
   }
   // Presence is optional on the WIRE; for THIS integration it is mandatory —
   // the mock tolerating a missing `integration` must not let ours stop sending it.
-  if (ev.integration !== "ogr-claude-code/1.0.0") errs.push(`integration ${ev.integration}`)
+  if (ev.integration !== "ogr-claude-code/2.0.0") errs.push(`integration ${ev.integration}`)
   if (typeof ev.payload !== "object" || ev.payload === null || Array.isArray(ev.payload)) {
     errs.push("payload must be an object")
   }
@@ -273,6 +274,74 @@ test("allow with spans on the held call denies (hook cannot redact a pending cal
   })
   eq((await runHook(payload("ls"))).decision, "allow")
   verdictHandler = allowVerdict()
+})
+
+/**
+ * Local secrets redaction: the hook's vantage is the harness's TRANSCRIPT,
+ * which holds the value in the clear — the proxy restored it on the way back
+ * from the provider. So the hook has to ask the proxy to put the tokens back
+ * before it reports, or it hands the runtime a secret the provider never saw
+ * and the runtime raises a leak that did not happen (D6).
+ */
+async function withMaskProxy(reply, body) {
+  const seen = []
+  const proxy = createServer((req, res) => {
+    let raw = ""
+    req.on("data", (c) => (raw += c))
+    req.on("end", () => {
+      seen.push({ path: req.url, body: raw ? JSON.parse(raw) : {} })
+      const { status, body: out } = reply(req)
+      res.writeHead(status, { "content-type": "application/json" })
+      res.end(JSON.stringify(out))
+    })
+  })
+  await new Promise((r) => proxy.listen(0, "127.0.0.1", r))
+  try {
+    return await body({ port: proxy.address().port, seen })
+  } finally {
+    await new Promise((r) => proxy.close(r))
+  }
+}
+
+test("the event carries the proxy's tokens and its redaction report", async () => {
+  await withMaskProxy(
+    () => ({
+      status: 200,
+      body: {
+        value: { tool_calls: [{ id: "t1", name: "Bash", arguments: { command: "deploy ${OGR_SECRET_1}" } }] },
+        changed: true,
+        redaction: { ruleset: "rs_abc", masked: [{ token: "${OGR_SECRET_1}", rule: "entity_api_key/openai_project" }] },
+      },
+    }),
+    async ({ port, seen }) => {
+      requests.length = 0
+      verdictHandler = () => ({ status: 200, body: { event_id: "e", provider: "m", decision: "allow" } })
+      eq((await runHook(payload("deploy sk-proj-realkeyhere"), { OGR_LOCAL_PORT: String(port) })).decision, "allow")
+
+      // The proxy was asked, and asked about the PAYLOAD only — the wire
+      // header is not text a secret rule has any business rewriting.
+      eq(seen.length, 1)
+      eq(seen[0].path, "/__ogr/mask")
+      eq(typeof seen[0].body.value.tool_calls, "object")
+      eq(seen[0].body.session, "sess-1")
+
+      const ev = requests[0].body
+      eq(ev.payload.tool_calls[0].arguments.command, "deploy ${OGR_SECRET_1}")
+      eq(ev.redaction.ruleset, "rs_abc")
+    },
+  )
+})
+
+test("no proxy: the event goes as built, and claims nothing", async () => {
+  requests.length = 0
+  verdictHandler = () => ({ status: 200, body: { event_id: "e", provider: "m", decision: "allow" } })
+  // Port 1 is never listening. Nothing masked this step, so nothing may say
+  // it was masked — the runtime's own detector is the one witness left, and
+  // a `redaction` field here would tell it to treat a real leak as a miss.
+  eq((await runHook(payload("deploy sk-proj-realkeyhere"), { OGR_LOCAL_PORT: "1" })).decision, "allow")
+  const ev = requests[0].body
+  eq(ev.redaction, undefined)
+  eq(ev.payload.tool_calls[0].arguments.command, "deploy sk-proj-realkeyhere")
 })
 
 test("transcript: the held call's generation maps to text/reasoning/model + provider id", async () => {

--- a/integrations/agent/codex/README.md
+++ b/integrations/agent/codex/README.md
@@ -101,6 +101,66 @@ The guardrail hook maps the same verdicts to `PreToolUse` output: `block` →
 `deny` (even under `bypassPermissions`), `allow` → silent, no verdict →
 `OGR_FAIL_MODE`.
 
+## Local secrets redaction: the value never leaves this machine
+
+Credentials in your prompts, files and tool output are replaced with
+`${OGR_SECRET_n}` **before the request leaves your machine**. The provider is
+given the placeholder; the real value goes back into the tool's arguments
+locally, after judgement, so the tool still runs. The ruleset is your
+organization's, served by the runtime — nothing here ships patterns.
+
+⚠️ **It needs a small proxy, and Codex leaves no alternative.** The other OGR
+integrations mask inside the agent's own process with a `fetch` interceptor.
+Codex's host is **Rust** and its hooks are separate processes, so there is no
+JavaScript seam inside Codex to install one on, and there is not going to be
+one. The next vantage down is a socket in front of it.
+
+```sh
+npm i -g @openguardrails/ogr-local
+```
+
+Then point Codex at it in `~/.codex/config.toml` — **which line depends on how
+you signed in**:
+
+```toml
+# signed in with ChatGPT
+openai_base_url = "http://127.0.0.1:8787/https/chatgpt.com/backend-api/codex"
+
+# signed in with an API key
+openai_base_url = "http://127.0.0.1:8787/https/api.openai.com/v1"
+```
+
+⚠️ **The top-level `openai_base_url`, not `model_providers.openai.base_url`.**
+Codex's built-in providers are deliberately not overridable
+(`merge_configured_model_providers`), and the top-level key is the one hook
+left for this. It also overrides the ChatGPT-login endpoint, which a
+per-provider entry would not reach.
+
+That is the only manual step. The plugin's `SessionStart` hook starts the
+daemon (idempotently — the port is the lock), works out which endpoint you
+would have been talking to by reading `auth.json`, and **reads `config.toml`
+back**: if the proxy is up but Codex is not pointed at it, it says so on every
+session start rather than letting a session look protected while nothing is
+masked. A hook is a child process and cannot change Codex's configuration.
+
+Turn it off with `OGR_LOCAL_REDACTION=0`; move the port with
+`OGR_LOCAL_PORT`; name the upstream yourself with `OGR_LOCAL_UPSTREAM`. See
+[`@openguardrails/ogr-local`](../ogr-local) for what the proxy does and does
+not do — in particular, it holds no credential, is not an open proxy, and
+offers no way to turn a token back into a secret.
+
+### What the runtime is told
+
+Both hooks read Codex's own rollout, which holds the value in the clear — the
+proxy restored it on the way back. So before reporting, each hook asks the
+proxy to put the tokens back, and attaches the step's `redaction`: the ruleset
+id and the tokens minted, never a value. Without that the runtime would be
+handed a secret the provider never saw and would correctly raise a leak that
+did not happen.
+
+**With no proxy running, the event goes as built and claims nothing** —
+nothing masked the step, so nothing may say it was masked.
+
 ## Honest limits: the fragment vantage
 
 A Codex hook never holds the model call — it holds **one tool call awaiting

--- a/integrations/agent/codex/config.example.toml
+++ b/integrations/agent/codex/config.example.toml
@@ -6,6 +6,28 @@
 # hand or can't use the plugin system. There is no build step — each hook is a
 # single zero-dependency Node ≥ 18 file under hooks/.
 
+# --- Local secrets redaction (optional but recommended) ----------------------
+# Credentials never leave this machine: `npm i -g @openguardrails/ogr-local`,
+# then point Codex's provider URL at the local masking proxy. WHICH line
+# depends on how you signed in — ChatGPT and API-key sign-ins are different
+# hosts, and the proxy carries the upstream in its path.
+#
+# ⚠️ The TOP-LEVEL key, not [model_providers.openai].base_url: Codex's
+# built-in providers are deliberately not overridable, and this is the one
+# hook left for it. It also covers the ChatGPT-login endpoint.
+#
+#   openai_base_url = "http://127.0.0.1:8787/https/chatgpt.com/backend-api/codex"   # ChatGPT sign-in
+#   openai_base_url = "http://127.0.0.1:8787/https/api.openai.com/v1"               # API key
+
+# --- SessionStart: start the masking proxy, and check Codex points at it -----
+[[hooks.SessionStart]]
+
+  [[hooks.SessionStart.hooks]]
+  type = "command"
+  command = "node /ABSOLUTE/PATH/TO/openguardrails/integrations/agent/codex/hooks/ogr-codex-session-start.mjs"
+  timeoutSec = 20
+  statusMessage = "OpenGuardrails local redaction"
+
 # --- Auto mode: remove prompts for calls an OGR runtime judges safe ----------
 # Fires in the approval path, before the user prompt. allow -> runs unattended,
 # block -> denied, everything else (incl. runtime unavailable) -> your prompt.

--- a/integrations/agent/codex/hooks/hooks.json
+++ b/integrations/agent/codex/hooks/hooks.json
@@ -1,6 +1,18 @@
 {
-  "description": "OpenGuardrails auto mode + guardrail for Codex.",
+  "description": "OpenGuardrails auto mode, guardrail and local secrets redaction for Codex.",
   "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${PLUGIN_ROOT}/hooks/ogr-codex-session-start.mjs\"",
+            "timeout": 20,
+            "statusMessage": "OpenGuardrails local redaction"
+          }
+        ]
+      }
+    ],
     "PermissionRequest": [
       {
         "matcher": "Bash|apply_patch|Read|Edit|Write|WebFetch|mcp__.*",

--- a/integrations/agent/codex/hooks/ogr-codex-automode-hook.mjs
+++ b/integrations/agent/codex/hooks/ogr-codex-automode-hook.mjs
@@ -181,7 +181,7 @@ function loadDenials(sessionId, turnId) {
  * row rather than minting a second and reporting the old build as dark — so
  * every replica overwrites the others' version.
  */
-const INTEGRATION = "ogr-codex-automode/1.0.0"
+const INTEGRATION = "ogr-codex-automode/2.0.0"
 
 // --- GuardEvent → /v1/evaluate → Verdict --------------------------------------
 
@@ -221,6 +221,48 @@ function buildEvent(input) {
     // inferred from message prefixes, which survives a compacted or trimmed
     // history. A grouping hint only — never authorization, ordering or policy.
     ...(input.session_id ? { session_hint: String(input.session_id) } : {}),
+  }
+}
+
+/** Where the local masking proxy listens, when one is running (`ogr-local`). */
+const LOCAL_PORT = Number(process.env.OGR_LOCAL_PORT || 8787)
+
+/**
+ * The event, with every secret the proxy masked on the way out replaced by
+ * the SAME `${OGR_SECRET_n}` the model provider was given (OGR 1.4).
+ *
+ * ⚠️⚠️ **A HOOK'S VANTAGE IS THE HARNESS'S OWN COPY, WHICH IS THE
+ * CLEARTEXT.** The proxy masks the request on its way to the provider and
+ * restores the reply's tool arguments on the way back, so what Codex hands
+ * this hook is the real credential. Reporting that would hand the runtime a
+ * secret the provider never saw, and the runtime would correctly raise a
+ * leak that did not happen. D6: the OGR client is an egress too.
+ *
+ * ⚠️ The proxy's `mask` is `maskKnown` — it can only REUSE tokens the
+ * request half minted, never allocate one. A token invented here would name
+ * nothing and restore to nothing.
+ *
+ * Never throws; a proxy that is not running means no local redaction, which
+ * is the state every deployment was in before this existed.
+ */
+async function sealed(event) {
+  try {
+    const res = await fetch(`http://127.0.0.1:${LOCAL_PORT}/__ogr/mask`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ value: event.payload, ...(event.session_hint ? { session: event.session_hint } : {}) }),
+      signal: AbortSignal.timeout(1500),
+    })
+    if (!res.ok) return event
+    const body = await res.json()
+    return {
+      ...event,
+      ...(body.value ? { payload: body.value } : {}),
+      ...(body.redaction ? { redaction: body.redaction } : {}),
+    }
+  } catch {
+    // Nothing masked this step, so nothing may claim it was masked.
+    return event
   }
 }
 
@@ -292,7 +334,7 @@ async function main() {
     abstain("denial limit reached for this turn; deferring to the user")
   }
 
-  const verdict = await evaluate(buildEvent(input))
+  const verdict = await evaluate(await sealed(buildEvent(input)))
   if (!verdict) abstain("runtime unavailable, deferring to the user")
 
   switch (verdict.decision) {

--- a/integrations/agent/codex/hooks/ogr-codex-hook.mjs
+++ b/integrations/agent/codex/hooks/ogr-codex-hook.mjs
@@ -152,7 +152,7 @@ function currentGenerationOf(transcriptPath) {
  * row rather than minting a second and reporting the old build as dark — so
  * every replica overwrites the others' version.
  */
-const INTEGRATION = "ogr-codex/1.0.0"
+const INTEGRATION = "ogr-codex/2.0.0"
 
 // --- GuardEvent → /v1/evaluate → Verdict --------------------------------------
 
@@ -192,6 +192,48 @@ function buildEvent(input) {
     // inferred from message prefixes, which survives a compacted or trimmed
     // history. A grouping hint only — never authorization, ordering or policy.
     ...(input.session_id ? { session_hint: String(input.session_id) } : {}),
+  }
+}
+
+/** Where the local masking proxy listens, when one is running (`ogr-local`). */
+const LOCAL_PORT = Number(process.env.OGR_LOCAL_PORT || 8787)
+
+/**
+ * The event, with every secret the proxy masked on the way out replaced by
+ * the SAME `${OGR_SECRET_n}` the model provider was given (OGR 1.4).
+ *
+ * ⚠️⚠️ **A HOOK'S VANTAGE IS THE HARNESS'S OWN COPY, WHICH IS THE
+ * CLEARTEXT.** The proxy masks the request on its way to the provider and
+ * restores the reply's tool arguments on the way back, so what Codex hands
+ * this hook is the real credential. Reporting that would hand the runtime a
+ * secret the provider never saw, and the runtime would correctly raise a
+ * leak that did not happen. D6: the OGR client is an egress too.
+ *
+ * ⚠️ The proxy's `mask` is `maskKnown` — it can only REUSE tokens the
+ * request half minted, never allocate one. A token invented here would name
+ * nothing and restore to nothing.
+ *
+ * Never throws; a proxy that is not running means no local redaction, which
+ * is the state every deployment was in before this existed.
+ */
+async function sealed(event) {
+  try {
+    const res = await fetch(`http://127.0.0.1:${LOCAL_PORT}/__ogr/mask`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ value: event.payload, ...(event.session_hint ? { session: event.session_hint } : {}) }),
+      signal: AbortSignal.timeout(1500),
+    })
+    if (!res.ok) return event
+    const body = await res.json()
+    return {
+      ...event,
+      ...(body.value ? { payload: body.value } : {}),
+      ...(body.redaction ? { redaction: body.redaction } : {}),
+    }
+  } catch {
+    // Nothing masked this step, so nothing may claim it was masked.
+    return event
   }
 }
 
@@ -254,7 +296,7 @@ async function main() {
   }
   if (!input.tool_name) emitAllow() // nothing held → nothing to judge
 
-  const verdict = await evaluate(buildEvent(input))
+  const verdict = await evaluate(await sealed(buildEvent(input)))
   if (!verdict) emitFailMode("runtime unavailable")
 
   if (verdict.decision === "block") emitDeny(reasonOf(verdict))

--- a/integrations/agent/codex/hooks/ogr-codex-session-start.mjs
+++ b/integrations/agent/codex/hooks/ogr-codex-session-start.mjs
@@ -1,0 +1,115 @@
+#!/usr/bin/env node
+/**
+ * OpenGuardrails — Codex SessionStart hook: bring up the local masking proxy,
+ * and say plainly whether Codex is actually pointed at it.
+ *
+ * ⚠️⚠️ **WHY A PROXY, AND WHY IT IS UNAVOIDABLE HERE.** The other
+ * integrations mask inside the agent's own process, with a `fetch`
+ * interceptor a plugin installs. Codex's host is **Rust**; its hooks are
+ * separate processes speaking JSON on stdin. There is no JavaScript seam
+ * inside Codex to install anything on, and there is not going to be one. The
+ * next vantage down is a socket in front of it, which is `ogr-local`.
+ *
+ * ⚠️ **THE BASE URL IS THE OPERATOR'S TO SET, AND THIS HOOK ONLY CHECKS IT.**
+ * Codex resolves its provider URL from `config.toml` at startup — a hook is a
+ * child process and can change nothing about it. What this hook can do is
+ * start the daemon and read the config back, so the one failure that would
+ * otherwise be silent — daemon healthy, Codex talking straight to the
+ * provider, nothing masked — is said out loud instead.
+ *
+ * ⚠️ `openai_base_url` (top level), not `model_providers.openai.base_url`:
+ * Codex's built-in providers are deliberately not overridable
+ * (`merge_configured_model_providers`), and the top-level key is the hook
+ * upstream left for exactly this. It also overrides the ChatGPT-login
+ * endpoint, which a per-provider entry would not reach.
+ *
+ * Never fails the session.
+ */
+import { execFileSync } from "node:child_process"
+import { readFileSync } from "node:fs"
+import { homedir } from "node:os"
+import { join } from "node:path"
+
+const PORT = Number(process.env.OGR_LOCAL_PORT || 8787)
+
+/**
+ * Which endpoint Codex would be talking to. A ChatGPT sign-in routes to the
+ * Codex backend, an API key to the public API — and the two are different
+ * hosts, so the proxy's path has to name the right one. `auth.json` is where
+ * Codex records which it holds.
+ */
+function upstream() {
+  if (process.env.OGR_LOCAL_UPSTREAM) return process.env.OGR_LOCAL_UPSTREAM
+  const home = process.env.CODEX_HOME || join(homedir(), ".codex")
+  try {
+    const auth = JSON.parse(readFileSync(join(home, "auth.json"), "utf8"))
+    if (auth?.tokens) return "https://chatgpt.com/backend-api/codex"
+  } catch {
+    /* no auth.json readable: assume the API-key endpoint */
+  }
+  return "https://api.openai.com/v1"
+}
+
+function expectedBaseUrl() {
+  const u = new URL(upstream())
+  const path = u.pathname === "/" ? "" : u.pathname.replace(/\/$/, "")
+  return `http://127.0.0.1:${PORT}/${u.protocol.replace(":", "")}/${u.host}${path}`
+}
+
+/** What `config.toml` currently says, if anything. */
+function configuredBaseUrl() {
+  const home = process.env.CODEX_HOME || join(homedir(), ".codex")
+  try {
+    const toml = readFileSync(join(home, "config.toml"), "utf8")
+    const m = /^\s*openai_base_url\s*=\s*["']([^"']+)["']/m.exec(toml)
+    return m ? m[1].replace(/\/+$/, "") : ""
+  } catch {
+    return ""
+  }
+}
+
+const say = (message) => process.stderr.write(`[OpenGuardrails] ${message}\n`)
+
+async function listening() {
+  try {
+    const res = await fetch(`http://127.0.0.1:${PORT}/__ogr/status`, { signal: AbortSignal.timeout(700) })
+    return res.ok ? await res.json() : null
+  } catch {
+    return null
+  }
+}
+
+async function main() {
+  if (process.env.OGR_LOCAL_REDACTION === "0" || process.env.OGR_LOCAL_REDACTION === "off") return
+  if (!process.env.OGR_API_KEY && !process.env.OGR_ENROLL_TOKEN) return
+
+  let status = await listening()
+  if (!status) {
+    try {
+      execFileSync(process.env.OGR_LOCAL_BIN || "ogr-local", ["ensure", "--port", String(PORT)], {
+        stdio: ["ignore", "ignore", "inherit"],
+        timeout: 15_000,
+      })
+    } catch {
+      say(
+        "could not start the local masking proxy. Install it with `npm i -g @openguardrails/ogr-local`, "
+        + "or set OGR_LOCAL_REDACTION=0 to stop this message. Secrets in your prompts will reach the model provider.",
+      )
+      return
+    }
+    status = await listening()
+  }
+  if (!status) return
+
+  const want = expectedBaseUrl()
+  if (configuredBaseUrl() !== want) {
+    say(
+      "the local masking proxy is running but Codex is not pointed at it — nothing is being masked. "
+      + `Add this to ~/.codex/config.toml and restart:\n    openai_base_url = "${want}"`,
+    )
+    return
+  }
+  say(`local secrets redaction active — ruleset ${status.ruleset || "(none yet)"}`)
+}
+
+main().catch(() => {})

--- a/integrations/agent/codex/package.json
+++ b/integrations/agent/codex/package.json
@@ -1,8 +1,8 @@
 {
   "name": "openguardrails-instrumentation-codex",
   "private": true,
-  "version": "1.0.0",
-  "description": "OpenGuardrails (OGR) v0.8 enforcement for OpenAI Codex — a PermissionRequest auto-mode hook that lets an OGR runtime approve safe tool calls (deferring everything unclear to you) and a PreToolUse guardrail that denies on block even when approvals are bypassed. Zero dependencies; the runtime decides.",
+  "version": "2.0.0",
+  "description": "OpenGuardrails (OGR) v1.0 for OpenAI Codex — a PermissionRequest auto-mode hook that lets an OGR runtime approve safe tool calls (deferring everything unclear to you), a PreToolUse guardrail that denies on block even when approvals are bypassed, and local secrets redaction through a loopback masking proxy so credentials never reach the model provider. The runtime decides.",
   "license": "Apache-2.0",
   "type": "module",
   "homepage": "https://openguardrails.com/docs/integrations/agent/codex/",
@@ -14,6 +14,20 @@
   "scripts": {
     "test": "node test/smoke.mjs && node test/automode.mjs"
   },
-  "keywords": ["codex", "openai-codex", "hook", "ai", "agent", "security", "guardrails", "ogr", "openguardrails"],
-  "files": ["hooks", "config.example.toml", "README.md"]
+  "keywords": [
+    "codex",
+    "openai-codex",
+    "hook",
+    "ai",
+    "agent",
+    "security",
+    "guardrails",
+    "ogr",
+    "openguardrails"
+  ],
+  "files": [
+    "hooks",
+    "config.example.toml",
+    "README.md"
+  ]
 }

--- a/integrations/agent/codex/test/mock-runtime.mjs
+++ b/integrations/agent/codex/test/mock-runtime.mjs
@@ -16,13 +16,15 @@ const EVENT_KEYS = [
   "agent_user", "llm_protocol", "payload",
 ].sort()
 
-// The schema has three optional fields — `integration`, `connection`,
-// `session_hint`. These hooks send two: `integration` (2026-08-17), the
-// reporter's own "name/version", and `session_hint`, the host's `session_id`
-// for the conversation. `connection` is a GATEWAY's field and deliberately
-// stays out of the allowlist, so a stray copy here would fail loudly. An
-// ALLOWLIST, not a relaxation — an unknown key is still a violation.
-const OPTIONAL_EVENT_KEYS = ["integration", "session_hint"]
+// The schema has four optional fields — `integration`, `connection`,
+// `session_hint`, `redaction`. These hooks send three: `integration`
+// (2026-08-17), the reporter's own "name/version"; `session_hint`, the host's
+// `session_id` for the conversation; and `redaction` (OGR 1.4), what the
+// local masking proxy replaced before the request left this machine.
+// `connection` is a GATEWAY's field and deliberately stays out of the
+// allowlist, so a stray copy here would fail loudly. An ALLOWLIST, not a
+// relaxation — an unknown key is still a violation.
+const OPTIONAL_EVENT_KEYS = ["integration", "session_hint", "redaction"]
 
 function validateEvent(ev) {
   const errs = []

--- a/integrations/agent/codex/test/smoke.mjs
+++ b/integrations/agent/codex/test/smoke.mjs
@@ -204,6 +204,65 @@ test("allow with spans on the held call denies (hook cannot redact a pending cal
   mock.verdictHandler = allowVerdict()
 })
 
+/**
+ * Local secrets redaction. A hook's vantage is Codex's own rollout, which
+ * holds the value in the clear — the masking proxy restored it on the way
+ * back from the provider. So the hook must ask the proxy to put the tokens
+ * back before it reports, or the runtime is handed a secret the provider
+ * never saw and raises a leak that did not happen (D6).
+ */
+async function withMaskProxy(reply, body) {
+  const { createServer } = await import("node:http")
+  const seen = []
+  const proxy = createServer((req, res) => {
+    let raw = ""
+    req.on("data", (c) => (raw += c))
+    req.on("end", () => {
+      seen.push({ path: req.url, body: raw ? JSON.parse(raw) : {} })
+      res.writeHead(200, { "content-type": "application/json" })
+      res.end(JSON.stringify(reply()))
+    })
+  })
+  await new Promise((r) => proxy.listen(0, "127.0.0.1", r))
+  try {
+    return await body({ port: proxy.address().port, seen })
+  } finally {
+    await new Promise((r) => proxy.close(r))
+  }
+}
+
+test("the event carries the proxy's tokens and its redaction report", async () => {
+  await withMaskProxy(
+    () => ({
+      value: { tool_calls: [{ id: "t1", name: "Bash", arguments: { command: "deploy ${OGR_SECRET_1}" } }] },
+      changed: true,
+      redaction: { ruleset: "rs_abc", masked: [{ token: "${OGR_SECRET_1}", rule: "entity_api_key/openai_project" }] },
+    }),
+    async ({ port, seen }) => {
+      mock.verdictHandler = allowVerdict()
+      mock.requests.length = 0
+      eq((await runHook(payload("deploy sk-proj-realkeyhere"), { OGR_LOCAL_PORT: String(port) })).decision, "allow")
+      eq(seen.length, 1)
+      eq(seen[0].path, "/__ogr/mask")
+      const ev = mock.requests[0].body
+      eq(ev.payload.tool_calls[0].arguments.command, "deploy ${OGR_SECRET_1}")
+      eq(ev.redaction.ruleset, "rs_abc")
+    },
+  )
+})
+
+test("no proxy: the event goes as built, and claims nothing", async () => {
+  mock.verdictHandler = allowVerdict()
+  mock.requests.length = 0
+  // Port 1 is never listening. Nothing masked this step, so nothing may say
+  // it was masked — a `redaction` field here would tell the runtime to treat
+  // a real leak as a miss against a ruleset that never ran.
+  eq((await runHook(payload("deploy sk-proj-realkeyhere"), { OGR_LOCAL_PORT: "1" })).decision, "allow")
+  const ev = mock.requests[0].body
+  eq(ev.redaction, undefined)
+  eq(ev.payload.tool_calls[0].arguments.command, "deploy sk-proj-realkeyhere")
+})
+
 test("rollout: the current generation maps to text/reasoning (older generations don't)", async () => {
   const dir = mkdtempSync(join(tmpdir(), "ogr-codex-test-"))
   const rollout = join(dir, "rollout.jsonl")

--- a/integrations/agent/dsh/README.md
+++ b/integrations/agent/dsh/README.md
@@ -102,6 +102,79 @@ and an override of the base `permission` table that adds the **Auto Mode by
 OGR** entry to the Permissions selector (with the shield icon, via the
 package's browser half — still zero core changes).
 
+## Local secrets redaction: the value never leaves this host
+
+Every credential in the outbound model request is replaced with
+`${OGR_SECRET_n}` **on this machine**, before the request goes anywhere. The
+runtime judges the placeholder, the provider is given the placeholder, and
+the real value is put back into the reply's tool-call arguments — locally,
+after judgement — so the tool still runs with the working credential. On by
+default; the ruleset is your organization's, served by the runtime
+([OGR 1.4](../../../specification/local-redaction.md)). **This plugin ships
+no patterns.**
+
+```yaml
+# cordis.yml — or leave it out entirely; the defaults are these
+localRedaction:
+  enabled: true               # OGR_LOCAL_REDACTION=0 turns it off
+  tiers: [strong, heuristic]  # OGR_LOCAL_REDACTION_TIERS
+  cachePath: ""               # OGR_RULES_CACHE; default ~/.openguardrails/rules-<hash>.json
+```
+
+### Where it sits, and why it sits there
+
+**At the HTTP client, and nowhere else — forced, not chosen.** The other
+integrations mask by rewriting the outbound request at a harness hook. dsh
+has no such seam: a loop-built `GenerateOptions` is frozen, its `messages`
+array is frozen, and `@deepseek-ai/dsh-agent-loop`'s own invariant asserts
+that `JSON.stringify(options.messages)` still equals
+`session.deriveMessages()`. Rewriting the request there is both impossible
+and a failed assertion. So the mask is the in-process interceptor on
+`globalThis.fetch` (and undici's dispatcher where it resolves), which is the
+seam every harness shares and for this one is the only seam there is.
+
+Three consequences worth knowing:
+
+- **The system prompt and tool schemas are covered**, which a message-level
+  hook would not be — the interceptor sees the whole body.
+- **There is no restore hook in this plugin, and none is needed.** dsh's
+  `exec.arguments` is `readonly` and `PreToolDecision` has no replace arm, so
+  a host-side restore is not expressible here; it does not have to be,
+  because the interceptor restores the reply's tool-call arguments a layer
+  below, before dsh ever parses them.
+- **Auxiliary calls are masked too.** Compaction and session titling are not
+  *judged* (they are machinery, not the conversation), but they are model
+  calls carrying your history, so the interceptor masks them like any other.
+
+### What the runtime is told, and what it is not
+
+Each event carries an optional `redaction` — the ruleset id and the tokens
+minted for that step, **never a value**. It is a claim, exactly like
+`integration`, and what it buys is diagnosis: a secret found on a step that
+reported a ruleset is a *miss* with a name (a stale ruleset, a plugin bug, a
+shape no regex covers), while the same secret on a step that reported nothing
+is just an ordinary finding.
+
+So the field is **omitted whenever nothing can be shown to be masking**, and
+in that case the event is sent unmasked as well. Reporting a step as
+protected while the provider got the value in the clear would blind the one
+witness that could still have caught it.
+
+### Honest limits
+
+- **One process, one map per conversation.** `dsh web` serves many
+  conversations from one process; each is masked under its own session key,
+  carried from the `llm/stream` seam down to the adapter's `fetch`. A
+  restore, however, consults every key this process has masked under — a
+  token can be minted at either vantage — so the isolation is real for
+  minting and reporting, and soft for restoring.
+- **A fetch captured before this plugin loaded is not covered.** The first
+  tool call after unintercepted model traffic warns, once, loudly. Nothing is
+  denied over it: a masking gap is not an enforcement decision.
+- **The first model call waits for the ruleset** (bounded by `timeoutMs`) on
+  a fresh install with no cache. That is deliberate — it is the request most
+  likely to carry a pasted credential.
+
 ## Known limitations
 
 - **Redaction spans are not applied yet.** A verdict's `modifications.spans`

--- a/integrations/agent/dsh/cordis.example.yml
+++ b/integrations/agent/dsh/cordis.example.yml
@@ -73,6 +73,25 @@
           preset: auto-mode
           unresolved: human
 
+    # Local secrets redaction (OGR 1.4). On by default; every field here is
+    # already the default, shown so the shape is discoverable.
+    #
+    # Credentials in the outbound model request become ${OGR_SECRET_n} on
+    # THIS machine — the runtime and the model provider are both given the
+    # placeholder, and the value goes back into the reply's tool-call
+    # arguments locally, after judgement. The patterns are your
+    # organization's, served by the runtime; this plugin ships none.
+    localRedaction:
+      enabled: true
+      # `strong` is carriers and issuer-prefixed keys; `heuristic` adds the
+      # gated assignment shapes (password=…, api_key: …). Drop `heuristic`
+      # if a config-heavy agent finds it masks values the model needs.
+      tiers:
+        - strong
+        - heuristic
+      # Empty = ~/.openguardrails/rules-<hash>.json, one cache per runtime.
+      cachePath: ""
+
 # Put "Auto Mode by OGR" in the Permissions selector. A patch replaces
 # the targeted row's WHOLE `config`, so the base presets are restated
 # verbatim around the new entry — merge `auto-mode` into your own table

--- a/integrations/agent/dsh/package.json
+++ b/integrations/agent/dsh/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openguardrails/dsh",
-  "version": "0.3.0",
-  "description": "OpenGuardrails for DeepSeek Harness (dsh): the v0.8 reference agent-direct integration \u2014 every model call judged twice at the loop's own seams (pre-model, post-model behind a held stream tail), one endpoint, no SDK. Includes Auto Mode: approval prompts answered by the step verdict. No core changes.",
+  "version": "0.4.0",
+  "description": "OpenGuardrails for DeepSeek Harness (dsh): the v1.0 reference agent-direct integration — every model call judged twice at the loop's own seams (pre-model, post-model behind a held stream tail), one endpoint, no SDK. Local secrets redaction keeps credentials on the host. Includes Auto Mode: approval prompts answered by the step verdict. No core changes.",
   "type": "module",
   "license": "Apache-2.0",
   "author": "OpenGuardrails",
@@ -66,6 +66,9 @@
     "@deepseek-ai/dsh-user-approval": {
       "optional": true
     }
+  },
+  "dependencies": {
+    "@openguardrails/local-redaction": "^0.1.0"
   },
   "devDependencies": {
     "@deepseek-ai/cordis": "^4.0.1",

--- a/integrations/agent/dsh/src/config.ts
+++ b/integrations/agent/dsh/src/config.ts
@@ -108,4 +108,50 @@ export interface GuardrailsOptions {
   heartbeatS?: number
   /** Auto mode: answer approval asks with the step verdict for auto-preset sessions. */
   auto?: AutoApprovalConfig
+  /** Local secrets redaction (default on). */
+  localRedaction?: LocalRedactionConfig
+}
+
+/** Which tiers of the served ruleset the local mask applies. */
+export type RedactionTier = "strong" | "heuristic"
+
+/**
+ * Local secrets redaction (OGR 1.4, specification/local-redaction.md): mask
+ * every credential in the OUTBOUND model request with `${OGR_SECRET_n}` so
+ * the value never leaves this host, judge the placeholder, and restore the
+ * value into the reply's tool-call arguments before the harness parses them.
+ * ON by default. The ruleset is the organization's, fetched from the runtime
+ * with the API key; this plugin ships none.
+ *
+ * ⚠️ dsh masks at the HTTP CLIENT and nowhere else, and that is forced, not
+ * chosen. A loop-built `GenerateOptions` is frozen, its `messages` array is
+ * frozen, and `@deepseek-ai/dsh-agent-loop`'s own invariant asserts that
+ * `JSON.stringify(options.messages)` still equals `session.deriveMessages()`
+ * — so rewriting the request at the `llm/stream` seam is both impossible and
+ * a failed assertion. The in-process interceptor is the seam every harness
+ * shares, and for this one it is the only seam there is.
+ */
+export interface LocalRedactionConfig {
+  /** Mask at all (default true; env `OGR_LOCAL_REDACTION=0|false|off` turns it off). */
+  enabled?: boolean
+  /** Where the fetched ruleset is cached (default `~/.openguardrails/rules-<hash>.json`; env `OGR_RULES_CACHE`). */
+  cachePath?: string
+  /** Which tiers to mask (default both; env `OGR_LOCAL_REDACTION_TIERS=strong,heuristic`). */
+  tiers?: RedactionTier[]
+}
+
+/** `OGR_LOCAL_REDACTION`: unset or anything but `0`/`false`/`off`/`no` means on. */
+export function envFlag(value: string | undefined, fallback: boolean): boolean {
+  if (value === undefined || value === "") return fallback
+  return !["0", "false", "off", "no"].includes(value.trim().toLowerCase())
+}
+
+/** `OGR_LOCAL_REDACTION_TIERS`: a comma list; unknown words are dropped, an empty result means both. */
+export function envTiers(value: string | undefined): RedactionTier[] | undefined {
+  if (value === undefined || value.trim() === "") return undefined
+  const tiers = value
+    .split(",")
+    .map((t) => t.trim().toLowerCase())
+    .filter((t): t is RedactionTier => t === "strong" || t === "heuristic")
+  return tiers.length > 0 ? tiers : undefined
 }

--- a/integrations/agent/dsh/src/index.ts
+++ b/integrations/agent/dsh/src/index.ts
@@ -67,6 +67,12 @@ import type {
 import type { ApprovalRequest } from "@deepseek-ai/dsh-user-approval"
 import { installSettingsSection, settingsNamespace } from "@deepseek-ai/dsh-settings"
 import {
+  installHttpInterceptor,
+  interceptorStatus,
+  LocalRedactor,
+  type HttpInterceptorHandle,
+} from "@openguardrails/local-redaction"
+import {
   DEFAULT_AUTO_PRESET,
   DEFAULT_HEARTBEAT_S,
   DEFAULT_RUNTIME_URL,
@@ -74,12 +80,17 @@ import {
   DEFAULT_TIMEOUT_MS,
   type AutoApprovalConfig,
   type AutoUnresolved,
+  envFlag,
+  envTiers,
   type FailMode,
   type GuardrailsOptions,
+  type LocalRedactionConfig,
+  type RedactionTier,
   type RuntimeOptions,
 } from "./config.js"
 import { LLM_PROTOCOL, RESPONSE_PROTOCOL, requestBody, ResponseAccumulator, TailGate } from "./llm-wire.js"
 import { hostAgentId, osUser } from "./platform.js"
+import { currentSessionKey, scopeSession, sessionKeyFor } from "./redaction.js"
 import { INTEGRATION, OgrClient, type WireEvent, type WireFinding, type WireVerdict } from "./wire.js"
 
 /** Cordis plugin name; the `id:` in `cordis.yml` is the deployment's own label. */
@@ -130,6 +141,18 @@ const AutoSchema: z<AutoApprovalConfig> = z.object({
     .description("What happens to an ask the step verdict never covered"),
 })
 
+const LocalRedactionSchema: z<LocalRedactionConfig> = z.object({
+  enabled: z.boolean().default(true)
+    .description("Mask secrets in the outbound model request so the value never leaves this host"),
+  cachePath: z.string()
+    .description("Where the served ruleset is cached (empty = ~/.openguardrails/rules-<hash>.json)"),
+  tiers: z.array(z.union([
+    z.const("strong").description("carriers and issuer-prefixed keys — unambiguous"),
+    z.const("heuristic").description("gated assignment shapes — password=…, api_key: …"),
+  ])).default(["strong", "heuristic"] as RedactionTier[])
+    .description("Which tiers of the served ruleset this host masks with"),
+})
+
 export const Config: z<Config> = z.object({
   runtime: RuntimeSchema.description("OpenGuardrails runtime connection and identity claims (also editable in Settings; environment fills gaps)"),
   failMode: z.union([
@@ -144,6 +167,7 @@ export const Config: z<Config> = z.object({
   heartbeatS: z.number().default(DEFAULT_HEARTBEAT_S)
     .description("Heartbeat cadence in seconds (build id + degraded-mode counters)"),
   auto: AutoSchema.description("Auto mode: answer approval asks with the step verdict for auto-preset sessions"),
+  localRedaction: LocalRedactionSchema.description("Local secrets redaction: mask credentials before the request leaves this host (OGR 1.4)"),
 })
 
 /** Bound on the per-call verdict table; released on `tools/result`, capped as a backstop. */
@@ -217,6 +241,44 @@ export function apply(ctx: Context, config: Config): void {
     onChange: () => {},
   })
 
+  // ---- local secrets redaction (OGR 1.4) ----------------------------------
+  //
+  // The value never leaves this host: every credential in the outbound model
+  // request becomes `${OGR_SECRET_n}`, the runtime judges the placeholder,
+  // and the interceptor puts the value back into the reply's tool-call
+  // arguments before dsh parses them. There is deliberately no restore hook
+  // in this plugin — dsh's `exec.arguments` is `readonly` and
+  // `PreToolDecision` has no replace arm, so a host-side restore is not
+  // expressible here, and it does not need to be: the reply is already
+  // restored a layer below.
+  const redaction = {
+    enabled: config.localRedaction?.enabled ?? envFlag(process.env.OGR_LOCAL_REDACTION, true),
+    cachePath: config.localRedaction?.cachePath || process.env.OGR_RULES_CACHE || undefined,
+    tiers: config.localRedaction?.tiers ?? envTiers(process.env.OGR_LOCAL_REDACTION_TIERS) ?? (["strong", "heuristic"] as RedactionTier[]),
+  }
+
+  let redactor: LocalRedactor | null = null
+  let http: HttpInterceptorHandle | null = null
+  /**
+   * Resolves when the ruleset is in hand (or its fetch has given up, bounded
+   * by `timeoutMs`). The FIRST model call awaits it.
+   *
+   * ⚠️ Without this the plugin starts, the fetch is in flight, and the first
+   * request of a fresh install races it — masking nothing and reporting
+   * `ruleset: ""`. That is precisely the request most likely to carry a
+   * pasted credential, and the race is invisible: everything downstream
+   * behaves as if the host had no rules, which is a state that also happens
+   * for honest reasons. One bounded wait at startup buys the guarantee.
+   */
+  let rulesetReady: Promise<void> = Promise.resolve()
+
+  /**
+   * Whether anything can be SHOWN to mask the model path — the gate on every
+   * `redaction` claim, because a step reported as protected while the
+   * provider got the value in the clear is worse than no report at all.
+   */
+  const masking = (): boolean => redactor !== null && redactor.masking
+
   const client = new OgrClient(
     { info: (m) => ctx.logger.info(m), warn: (m) => ctx.logger.warn(m) },
     () => {
@@ -225,6 +287,57 @@ export function apply(ctx: Context, config: Config): void {
     },
     () => config.timeoutMs ?? DEFAULT_TIMEOUT_MS,
   )
+
+  if (redaction.enabled) {
+    const r = new LocalRedactor({
+      source: () => {
+        const s = runtimeSettings()
+        return s.apiKey ? { runtimeUrl: s.url || DEFAULT_RUNTIME_URL, apiKey: s.apiKey } : null
+      },
+      ...(redaction.cachePath ? { cachePath: redaction.cachePath } : {}),
+      tiers: redaction.tiers,
+      timeoutMs: config.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+      log: { info: (m) => ctx.logger.info(m), warn: (m) => ctx.logger.warn(m) },
+    })
+    redactor = r
+    rulesetReady = r.start().catch(() => {})
+    http = installHttpInterceptor({
+      redactor: r,
+      // The session the `llm/stream` pull in flight on this async chain
+      // belongs to. The body cannot answer it — a dsh request carries no
+      // session id — so it is carried by `redaction.ts`.
+      sessionKey: () => currentSessionKey(),
+      unprotected: failMode === "closed" ? "refuse" : "proceed",
+      log: { info: (m) => ctx.logger.info(m), warn: (m) => ctx.logger.warn(m) },
+      onMiss: () =>
+        warn(
+          "model traffic is not passing through the HTTP interceptor — nothing is masked locally. "
+          + "This harness has no second masking seam (a loop-built request is frozen), so secrets are reaching the model provider.",
+        ),
+    })
+
+    // ⚠️⚠️ WHY A STATUS CHECK COUNTS AS PROOF HERE, when for other harnesses
+    // only `sawTraffic` does. `masking` gates every `redaction` claim, and
+    // `sawTraffic` cannot be true before the first model call — so the first
+    // request of every process would go out unclaimed and, worse, unmasked
+    // (the gate is what decides whether we mint at all). dsh's DeepSeek
+    // adapter calls the BARE GLOBAL `fetch` at call time
+    // (`llm-deepseek/src/adapter.ts` — `await fetch(...)`, resolved from the
+    // global scope on each call), never a reference captured at import, so
+    // for THIS harness "the wrapper is installed on globalThis.fetch" is a
+    // sound proof of coverage before any traffic has flowed. That is a fact
+    // about dsh's source, re-check it on a major dsh upgrade; it is exactly
+    // the assumption `onMiss` above exists to catch if it ever stops holding.
+    ctx.effect(() => {
+      void http?.ready.then(() => {
+        if (interceptorStatus().fetch === "wrapped") r.fallbackActive = true
+      })
+      return () => {
+        http?.uninstall()
+        http = null
+      }
+    })
+  }
 
   // One harness process per machine → machine-scoped identity, resolved once.
   const agentId = hostAgentId()
@@ -259,10 +372,40 @@ export function apply(ctx: Context, config: Config): void {
   // instead of silent (degraded-mode spec, "loud signaling").
   const counters = { events_sent: 0, evaluate_errors: 0, unresolved_spans: 0 }
 
-  /** One evaluate, counted. A `null` verdict is the caller's fail-mode decision. */
-  const judge = async (event: WireEvent): Promise<WireVerdict | null> => {
+  /**
+   * One evaluate, counted, and the LAST place an event can still be masked.
+   *
+   * ⚠️⚠️ **THE ORDERING HERE IS THE WHOLE DESIGN, AND IT IS NOT THE ORDERING
+   * THE OTHER INTEGRATIONS HAVE.** hermes and opencode rewrite the outbound
+   * request at a harness hook, so by the time they build an event the
+   * secrets are already tokens and a `maskKnown` pass suffices. dsh has no
+   * such hook — the request is frozen — so this plugin is the FIRST thing on
+   * the host to see the step, and it MINTS here: `maskValue` walks the
+   * payload, mints `${OGR_SECRET_n}` for what it finds, and the interceptor
+   * a few frames later meets the same values already in the session map and
+   * reuses the same tokens. The provider and the runtime are therefore given
+   * the identical text. Reversing these two (letting the interceptor mint
+   * first) would need the request event to be judged after the model call,
+   * which is the one thing a pre-model guard cannot do.
+   *
+   * ⚠️ Gated on `masking()`, never merely on having a ruleset. Masking the
+   * event while the provider copy went out in the clear would take the one
+   * witness that could have caught the leak — AIRS's own `secrets` detector
+   * — and blind it, silently. Unproven ⇒ send what happened.
+   */
+  const judge = async (sessionKey: string, event: WireEvent): Promise<WireVerdict | null> => {
     counters.events_sent += 1
-    const verdict = await client.evaluate(event)
+    let sealed = event
+    if (redactor && masking()) {
+      // The PAYLOAD only. `maskLeaves` walks every string leaf and its
+      // structural-key skip list knows nothing of the wire header, so
+      // handing it the whole event would let a rule fire on `agent_id` or
+      // `step_id` and tokenise a coordinate the runtime pairs events by.
+      sealed = { ...event, payload: redactor.maskValue(sessionKey, event.payload).value }
+      const report = redactor.report(sessionKey)
+      if (report) sealed = { ...sealed, redaction: report }
+    }
+    const verdict = await client.evaluate(sealed)
     if (!verdict) counters.evaluate_errors += 1
     return verdict
   }
@@ -336,8 +479,17 @@ export function apply(ctx: Context, config: Config): void {
       // bookkeeping — v0.8 left the producer nothing else to track.
       const stepId = randomUUID()
 
+      // The ruleset, if this is the first call and it is still in flight.
+      if (redaction.enabled) await rulesetReady
+
+      // WHICH CONVERSATION this request's secrets belong to. `dsh web` serves
+      // many conversations from one process, so a shared key would let a
+      // token minted in one answer a restore in another — the wrong secret
+      // spliced into a tool call, silently. See `redaction.ts`.
+      const sessionKey = sessionKeyFor(options.sessionId)
+
       // -- step/request: judged before the model sees it --
-      const reqVerdict = await judge({
+      const reqVerdict = await judge(sessionKey, {
         kind: "step/request",
         step_id: stepId,
         ...identity(),
@@ -374,7 +526,11 @@ export function apply(ctx: Context, config: Config): void {
       // stream in.
       const accumulator = new ResponseAccumulator(options.model)
       const gate = new TailGate(tailChars)
-      for await (const chunk of next()) {
+      // `scopeSession` is what carries `sessionKey` down to the adapter's
+      // `fetch`, and with it to the interceptor that masks the body. It
+      // wraps the PULL, not the construction — the difference is silent and
+      // it is a cross-session leak; the module note has the measurement.
+      for await (const chunk of scopeSession(sessionKey, next())) {
         accumulator.push(chunk)
         yield* gate.feed(chunk)
       }
@@ -386,7 +542,7 @@ export function apply(ctx: Context, config: Config): void {
       }
 
       // -- step/response: the whole reassembled answer, judged once --
-      const resVerdict = await judge({
+      const resVerdict = await judge(sessionKey, {
         kind: "step/response",
         step_id: stepId,
         ...identity(),
@@ -449,6 +605,13 @@ export function apply(ctx: Context, config: Config): void {
   // permissive listener that returns `allow` without delegating short-circuits
   // the waterfall. The monotonic guard below covers reordering regardless.
   ctx.on("tools/pre-execute", async (exec: ToolExecution, next): Promise<PreToolDecision> => {
+    // The interceptor's self-check, at the one moment it can be made: a tool
+    // call is about to run, so a model call has certainly happened, so
+    // traffic that never reached the interceptor proves it is not on the
+    // path. Warns ONCE. It never denies — nothing about local redaction is
+    // an enforcement decision, and turning a masking gap into a stopped
+    // agent would be a second authorization axis.
+    http?.noteToolCall()
     const verdict = callVerdicts.get(String(exec.callId))
     if (verdict && !verdict.allow) {
       return { kind: "deny", reason: `[OpenGuardrails] ${verdict.reason}` }
@@ -492,12 +655,22 @@ export function apply(ctx: Context, config: Config): void {
   ctx.effect(() => {
     const beat = (): void => {
       if (!client.enabled) return
-      void client.heartbeat({
-        integration: INTEGRATION,
-        agent_id: agentId,
-        interval_s: heartbeatS,
-        counters: { ...counters },
-      })
+      void client
+        .heartbeat({
+          integration: INTEGRATION,
+          agent_id: agentId,
+          interval_s: heartbeatS,
+          counters: { ...counters },
+          // The ruleset this process masks with. The reply names the CURRENT
+          // one, which is how a running plugin learns the org edited its
+          // rules — within one interval, and without polling the feed. Sent
+          // only while something provably masks: an id from a process that
+          // is not masking would read as coverage.
+          ...(masking() ? { rules: { id: redactor!.rulesetId } } : {}),
+        })
+        .then((reply) => {
+          if (reply && redactor) redactor.onHeartbeat(reply)
+        })
     }
     beat()
     const timer = setInterval(beat, heartbeatS * 1000)

--- a/integrations/agent/dsh/src/redaction.ts
+++ b/integrations/agent/dsh/src/redaction.ts
@@ -1,0 +1,80 @@
+/**
+ * Local secrets redaction for dsh: which SESSION a masked model request
+ * belongs to.
+ *
+ * The mask itself is `@openguardrails/local-redaction`'s in-process HTTP
+ * interceptor — the only seam this harness has (a loop-built
+ * `GenerateOptions` is frozen and `dsh-agent-loop`'s invariant asserts its
+ * `messages` still equal `session.deriveMessages()`, so the `llm/stream`
+ * waterfall can observe a request but never rewrite one). The interceptor
+ * sees an HTTP body and nothing else, and a dsh request body carries no
+ * session id, so the session key has to be carried out-of-band from the
+ * `llm/stream` seam — where dsh does hand us `options.sessionId` — down to
+ * the `fetch` the adapter makes several frames later.
+ *
+ * ⚠️⚠️ **THE OBVIOUS WAY TO DO THAT SILENTLY FAILS, AND ITS FAILURE IS A
+ * CROSS-SESSION LEAK.** `AsyncLocalStorage.run(key, () => next())` looks
+ * right and is not: `next()` only CONSTRUCTS the downstream async iterable,
+ * and an async generator's body runs when the CONSUMER pulls — outside the
+ * scope that has already exited. Measured, two concurrent sessions:
+ *
+ *     als.run(key, () => next())        →  the adapter's fetch sees `undefined`
+ *     await als.run(key, () => it.next())  →  A sees A, B sees B
+ *
+ * With `undefined` every session collapses onto one map key. That is not
+ * merely imprecise: `dsh web` serves many conversations from one process, so
+ * one shared key means a token minted in one conversation answers a restore
+ * in another, and the wrong secret is spliced into a tool call. Nothing
+ * throws — the restore succeeds, with the wrong value.
+ *
+ * So {@link scopeSession} pulls each chunk INSIDE the scope: whatever that
+ * pull starts — the adapter's `fetch`, and the interceptor inside it —
+ * inherits the store, and the scope is re-entered for every resumption
+ * rather than captured once at construction.
+ */
+import { AsyncLocalStorage } from "node:async_hooks"
+import { DEFAULT_SESSION_KEY } from "@openguardrails/local-redaction"
+
+const storage = new AsyncLocalStorage<string>()
+
+/**
+ * The session key the interceptor should mask this request under: whichever
+ * `llm/stream` pull is in flight on this async chain, else the process-wide
+ * default (an auxiliary call, or a model call made outside the loop).
+ */
+export function currentSessionKey(): string {
+  return storage.getStore() ?? DEFAULT_SESSION_KEY
+}
+
+/**
+ * The map key for one dsh session. A model call the loop did not raise has
+ * no session id and shares the process-wide key — the same fallback
+ * {@link currentSessionKey} answers with, so both vantages agree.
+ */
+export function sessionKeyFor(sessionId: unknown): string {
+  return sessionId === undefined || sessionId === null ? DEFAULT_SESSION_KEY : String(sessionId)
+}
+
+/**
+ * Re-yield `inner`, pulling every chunk inside `key`'s scope.
+ *
+ * The pull is what matters — see the module note. Cancellation and early
+ * exit are forwarded so a dropped stream still tears the adapter down: a
+ * `for await` that breaks calls `return()` on the iterator, and losing that
+ * would leak the underlying HTTP response.
+ */
+export async function* scopeSession<T>(key: string, inner: AsyncIterable<T>): AsyncIterable<T> {
+  const it = inner[Symbol.asyncIterator]()
+  try {
+    for (;;) {
+      const step = await storage.run(key, () => it.next())
+      if (step.done) return
+      yield step.value
+    }
+  } finally {
+    // `return` is optional on the async-iterator protocol; a generator has it.
+    await storage.run(key, async () => {
+      await it.return?.(undefined as never)
+    })
+  }
+}

--- a/integrations/agent/dsh/src/wire.ts
+++ b/integrations/agent/dsh/src/wire.ts
@@ -31,7 +31,7 @@
  * WHO REPORTED IT — `"name/version"`, on every event AND on the heartbeat.
  * One constant so the two can never name different builds.
  */
-export const INTEGRATION = "ogr-dsh/0.3.0"
+export const INTEGRATION = "ogr-dsh/0.4.0"
 
 export interface WireEvent {
   kind: "step/request" | "step/response"
@@ -61,6 +61,20 @@ export interface WireEvent {
    * traffic it produced and nothing can overwrite it.
    */
   integration?: string
+  /**
+   * WHAT THIS HOST MASKED BEFORE SENDING (OGR 1.4, the fourth optional wire
+   * field). Tokens, never values: the ruleset id this step ran under and the
+   * `${OGR_SECRET_n}` placeholders minted for it.
+   *
+   * ⚠️ It is a CLAIM, exactly like `integration` — nothing bounds what a
+   * producer says about itself. What it buys is DIAGNOSIS: a secret found on
+   * a step that reported a ruleset is a MISS with a name (stale ruleset, a
+   * plugin bug, or a shape no regex covers), while the same secret on a step
+   * that reported nothing is just an ordinary finding. Absent is therefore
+   * the honest answer whenever nothing can be SHOWN to be masking — this
+   * plugin omits the field rather than assert coverage it cannot prove.
+   */
+  redaction?: { ruleset: string; masked: Array<{ token: string; rule: string }> }
 }
 
 /** One v0.8 finding — what was found, where, and what it contributed. */
@@ -107,6 +121,17 @@ export interface WireHeartbeat {
   agent_id?: string
   interval_s?: number
   counters?: Record<string, number>
+  /**
+   * The local-redaction ruleset this process is masking with. The reply
+   * carries the CURRENT id, so a beat is how a running plugin learns its
+   * ruleset moved — within one interval, without polling the feed.
+   */
+  rules?: { id: string }
+}
+
+/** What `/v1/heartbeat` answers. Only the ruleset id is read. */
+export interface WireHeartbeatReply {
+  rules?: { id?: string }
 }
 
 /** Log sink; the plugin passes dsh's own logger so wire noise stays in the harness log. */
@@ -188,14 +213,18 @@ export class OgrClient {
    * never a lost enforcement, so it warns and moves on. This is where the
    * build id and the degraded-mode counters travel.
    */
-  async heartbeat(body: WireHeartbeat): Promise<void> {
+  async heartbeat(body: WireHeartbeat): Promise<WireHeartbeatReply | null> {
     try {
       const res = await this.post("/v1/heartbeat", body)
-      if (res && !res.ok) {
+      if (!res) return null
+      if (!res.ok) {
         this.log.warn(`[openguardrails] heartbeat answered ${res.status}`)
+        return null
       }
+      return (await res.json()) as WireHeartbeatReply
     } catch (err) {
       this.log.warn(`[openguardrails] heartbeat failed (${String(err)})`)
+      return null
     }
   }
 }

--- a/integrations/agent/dsh/tests/local-redaction.spec.mjs
+++ b/integrations/agent/dsh/tests/local-redaction.spec.mjs
@@ -1,0 +1,147 @@
+/**
+ * Local secrets redaction, end to end through the real plugin: what the
+ * runtime is shown, and what it is told about it.
+ *
+ * ⚠️ The load-bearing claim is NOT "a token appeared". It is that the token
+ * the runtime judges is the SAME token the model provider was given — one
+ * session map, both destinations. dsh is the only integration that mints on
+ * the OGR event rather than at a request-rewrite hook (its request is
+ * frozen), so this is where that ordering is pinned.
+ */
+import { test } from "node:test"
+import assert from "node:assert/strict"
+import { mkdtempSync, rmSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+
+import { boot } from "./harness.mjs"
+import { withRuntime, TEST_RULESET } from "./mock-runtime.mjs"
+
+const KEY = "sk-proj-abcdefghijklmnopqrstuvwx"
+
+const REQUEST = {
+  provider: "test", model: "test-model", system: "You are dsh.",
+  messages: [{
+    id: "m1", role: "user",
+    content: [{ type: "text", text: `deploy with ${KEY} please` }],
+    source: { kind: "user" },
+  }],
+  tools: [],
+  sessionId: "sess-1",
+}
+
+const ANSWER = [
+  { type: "block-start", index: 0, blockType: "text" },
+  { type: "block-end", index: 0, block: { type: "text", text: "Done." } },
+  { type: "finish", reason: { kind: "stop" } },
+]
+
+/** A cache path under the OS temp dir — never the operator's real ~/.openguardrails. */
+function withCache(body) {
+  const dir = mkdtempSync(join(tmpdir(), "ogr-dsh-rules-"))
+  const saved = process.env.OGR_RULES_CACHE
+  process.env.OGR_RULES_CACHE = join(dir, "rules.json")
+  return (async () => {
+    try {
+      return await body()
+    } finally {
+      if (saved === undefined) delete process.env.OGR_RULES_CACHE
+      else process.env.OGR_RULES_CACHE = saved
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })()
+}
+
+test("the runtime is shown a token, never the key", async () => {
+  await withCache(() =>
+    withRuntime(boot, {}, () => "allow", async ({ stream, runtime }) => {
+      await stream(REQUEST, ANSWER)
+      const sent = JSON.stringify(runtime.received)
+      assert.equal(sent.includes(KEY), false, "the API key reached the runtime in the clear")
+      assert.match(sent, /\$\{OGR_SECRET_1\}/, "the key was not replaced by a placeholder")
+    }, { rules: TEST_RULESET }))
+})
+
+test("the step reports WHAT it masked — tokens and a ruleset id, never values", async () => {
+  await withCache(() =>
+    withRuntime(boot, {}, () => "allow", async ({ stream, runtime }) => {
+      await stream(REQUEST, ANSWER)
+      const request = runtime.received.find((e) => e.kind === "step/request")
+      assert.equal(request.redaction.ruleset, TEST_RULESET.id)
+      assert.deepEqual(request.redaction.masked, [
+        { token: "${OGR_SECRET_1}", rule: "entity_api_key/openai_project" },
+      ])
+      // The report is DRAINED: the same token must not be claimed twice, or
+      // a coverage count is a count of events rather than of secrets.
+      const response = runtime.received.find((e) => e.kind === "step/response")
+      assert.deepEqual(response.redaction.masked, [])
+    }, { rules: TEST_RULESET }))
+})
+
+test("one value, one token — across steps of the same session", async () => {
+  await withCache(() =>
+    withRuntime(boot, {}, () => "allow", async ({ stream, runtime }) => {
+      await stream(REQUEST, ANSWER)
+      await stream(REQUEST, ANSWER)
+      const requests = runtime.received.filter((e) => e.kind === "step/request")
+      assert.equal(requests.length, 2)
+      const tokens = requests.map((e) => JSON.stringify(e.payload).match(/\$\{OGR_SECRET_\d+\}/)[0])
+      assert.equal(tokens[0], tokens[1], "the same secret must map to the same token, or a restore picks one at random")
+      // Minted ONCE. The second step re-uses the map entry, so it has
+      // nothing new to report — that is what makes `masked` a count of
+      // secrets rather than of mentions.
+      assert.deepEqual(requests[1].redaction.masked, [])
+    }, { rules: TEST_RULESET }))
+})
+
+test("two conversations get their own tokens", async () => {
+  await withCache(() =>
+    withRuntime(boot, {}, () => "allow", async ({ stream, runtime }) => {
+      await stream(REQUEST, ANSWER)
+      await stream({ ...REQUEST, sessionId: "sess-2" }, ANSWER)
+      const per = runtime.received
+        .filter((e) => e.kind === "step/request")
+        .map((e) => e.redaction.masked.length)
+      assert.deepEqual(per, [1, 1], "a second conversation must mint into its own map, not inherit the first's")
+    }, { rules: TEST_RULESET }))
+})
+
+test("no ruleset served = on but unprotected, said on the wire rather than implied", async () => {
+  await withCache(() =>
+    withRuntime(boot, {}, () => "allow", async ({ stream, runtime }) => {
+      await stream(REQUEST, ANSWER)
+      const request = runtime.received.find((e) => e.kind === "step/request")
+      // The key goes out in the clear — there is nothing to mask it with —
+      // and the report says exactly that: masking is ON, ruleset is none.
+      // A runtime reads this as `unprotected`, which is a different thing
+      // from a host that never reported at all.
+      assert.equal(request.redaction.ruleset, "")
+      assert.equal(JSON.stringify(request.payload).includes(KEY), true)
+    }))
+})
+
+test("switched off = no claim at all", async () => {
+  await withCache(() =>
+    withRuntime(boot, { localRedaction: { enabled: false } }, () => "allow", async ({ stream, runtime }) => {
+      await stream(REQUEST, ANSWER)
+      for (const event of runtime.received) {
+        assert.equal("redaction" in event, false, "a host that is not masking must not send the field")
+      }
+    }, { rules: TEST_RULESET }))
+})
+
+test("the heartbeat advertises the ruleset once there is one to advertise", async () => {
+  await withCache(() =>
+    withRuntime(boot, { heartbeatS: 0.1 }, () => "allow", async ({ stream, runtime }) => {
+      // The FIRST beat leaves at plugin start, before the interceptor has
+      // settled and before the ruleset has landed — and it carries no
+      // `rules` at all, which is the honest answer: an id from a process
+      // that is not yet masking would read as coverage.
+      assert.equal(runtime.beats[0].rules, undefined)
+      await stream(REQUEST, ANSWER)
+      await new Promise((r) => setTimeout(r, 250))
+      const advertised = runtime.beats.filter((b) => b.rules !== undefined)
+      assert.ok(advertised.length > 0, "no beat ever named the ruleset")
+      assert.equal(advertised.at(-1).rules.id, TEST_RULESET.id)
+    }, { rules: TEST_RULESET }))
+})

--- a/integrations/agent/dsh/tests/mock-runtime.mjs
+++ b/integrations/agent/dsh/tests/mock-runtime.mjs
@@ -20,13 +20,15 @@ const EVENT_FIELDS = [
 ]
 
 /**
- * The schema has three optional fields — `integration`, `connection`,
- * `session_hint`. This plugin sends one: `integration` (2026-08-17), the
- * reporter's own `"name/version"`. An ALLOWLIST, not a relaxation — an unknown key is still a
- * violation; only a MISSING `integration` stopped being one, which is what lets
- * a runtime and a reporter roll forward independently.
+ * The schema has four optional fields — `integration`, `connection`,
+ * `session_hint`, `redaction`. This plugin sends two: `integration`
+ * (2026-08-17), the reporter's own `"name/version"`, and `redaction`
+ * (OGR 1.4, 2026-08-29), what this host masked before sending. An ALLOWLIST,
+ * not a relaxation — an unknown key is still a violation; only a MISSING
+ * optional stopped being one, which is what lets a runtime and a reporter
+ * roll forward independently.
  */
-const OPTIONAL_EVENT_FIELDS = ["integration"]
+const OPTIONAL_EVENT_FIELDS = ["integration", "redaction"]
 
 const KINDS = ["step/request", "step/response"]
 const PROTOCOLS = ["openai.chat", "openai.responses", "anthropic.messages", "canonical"]
@@ -55,7 +57,34 @@ function eventIssues(e) {
  *   for the decision alone, or an object `{decision, findings, unjudged,
  *   modifications}` to control the whole verdict.
  */
-export async function startMockRuntime(decide = () => "allow") {
+/**
+ * One served secret ruleset, in the `ogr-re-1` dialect the plugins compile.
+ * Deliberately ONE rule with a shape no other fixture uses: a test that
+ * asserts a token appeared should not be able to pass because some other
+ * rule happened to fire.
+ */
+export const TEST_RULESET = {
+  id: "rs_test0001",
+  generated_at: "2026-08-29T00:00:00Z",
+  family: "secrets",
+  dialect: "ogr-re-1",
+  rules: [
+    {
+      id: "entity_api_key",
+      category: "secrets",
+      severity: "critical",
+      tier: "strong",
+      flags: "",
+      patterns: [{ id: "openai_project", source: "sk-proj-[A-Za-z0-9_-]{20,}" }],
+      examples: {
+        match: ["sk-proj-abcdefghijklmnopqrstuvwx"],
+        nomatch: ["sk-proj-short", "an ordinary sentence"],
+      },
+    },
+  ],
+}
+
+export async function startMockRuntime(decide = () => "allow", { rules = null } = {}) {
   const received = []
   const beats = []
   const invalid = []
@@ -93,13 +122,22 @@ export async function startMockRuntime(decide = () => "allow") {
           latency_ms: 1,
         })
       }
+      if (req.method === "GET" && req.url.endsWith("/v1/rules")) {
+        if (!rules) return reply(404, { error: "not found" })
+        // The real route's shape: the ruleset WRAPPED, and the ETag is the
+        // quoted id (`web/src/app/api/public/ogr/v1/rules/route.ts`).
+        res.writeHead(200, { "content-type": "application/json", etag: `"${rules.id}"` })
+        return res.end(JSON.stringify({ ruleset: rules }))
+      }
       if (req.url.endsWith("/v1/heartbeat")) {
         if (json.integration === undefined && json.agent_id === undefined) {
           invalid.push({ event: json, issues: ["heartbeat needs integration or agent_id"] })
           return reply(400, { error: "invalid_body" })
         }
         beats.push(json)
-        return reply(200, { ok: true })
+        // The reply names the CURRENT ruleset: how a running plugin learns
+        // its own is stale without polling the feed.
+        return reply(200, { ok: true, ...rules ? { rules: { id: rules.id } } : {} })
       }
       // /v1/ingest falls through here too: it left the protocol in v0.8, so
       // a plugin that still calls it sees the 404 a v0.8 runtime would give.
@@ -131,8 +169,8 @@ export async function startMockRuntime(decide = () => "allow") {
  * shell's. Any event the mock rejected fails the test — conformance is not
  * optional.
  */
-export async function withRuntime(bootFn, config, decide, body) {
-  const runtime = await startMockRuntime(decide)
+export async function withRuntime(bootFn, config, decide, body, { rules = null } = {}) {
+  const runtime = await startMockRuntime(decide, { rules })
   const saved = { ...process.env }
   process.env.OGR_RUNTIME_URL = runtime.url
   process.env.OGR_API_KEY = "ogr_mockmockmockmockmockmockmock"

--- a/integrations/agent/dsh/tests/recipe.spec.mjs
+++ b/integrations/agent/dsh/tests/recipe.spec.mjs
@@ -307,7 +307,7 @@ test("the heartbeat carries the build id and the degraded-mode counters", async 
     // live-but-idle agent.
     await tick(20)
     assert.ok(runtime.beats.length >= 1, "a beat arrived before the first event")
-    assert.equal(runtime.beats[0].integration, "ogr-dsh/0.3.0")
+    assert.equal(runtime.beats[0].integration, "ogr-dsh/0.4.0")
     assert.match(runtime.beats[0].agent_id, /^dsh-/)
 
     // An outage shows up in the counters — v0.8's only record that steps

--- a/integrations/agent/dsh/tests/redaction.spec.mjs
+++ b/integrations/agent/dsh/tests/redaction.spec.mjs
@@ -1,0 +1,86 @@
+/**
+ * The session key a masked request is filed under.
+ *
+ * This is the one part of dsh's local redaction that can be wrong WITHOUT
+ * anything failing: the mask still happens, the restore still succeeds, and
+ * the value it splices in is another conversation's secret. So the test is
+ * written against the failure, not the feature — it drives two conversations
+ * concurrently through the same shape the plugin uses (`llm/stream` hands a
+ * session id, the adapter's `fetch` happens several frames later inside a
+ * downstream async generator) and asserts each fetch sees its OWN key.
+ *
+ * The companion assertion is the point: the same test run against the
+ * obvious `als.run(key, () => next())` sees `undefined` at both fetches.
+ */
+import { test } from "node:test"
+import assert from "node:assert/strict"
+import { AsyncLocalStorage } from "node:async_hooks"
+
+import { currentSessionKey, scopeSession, sessionKeyFor } from "../dist/redaction.js"
+
+/**
+ * A stand-in for dsh's adapter: an async generator that makes its HTTP call
+ * midway and reports the session key the interceptor would have read.
+ */
+async function* adapter(seen, chunks = 3) {
+  await new Promise((r) => setTimeout(r, 4))
+  seen.push(currentSessionKey()) // the interceptor's vantage: inside the fetch
+  for (let i = 0; i < chunks; i += 1) {
+    yield i
+    await new Promise((r) => setTimeout(r, 2))
+  }
+}
+
+/** Cordis puts other listeners between the plugin and the adapter. */
+async function* between(inner) {
+  for await (const c of inner) yield c
+}
+
+test("two conversations in one process do not share a session key", async () => {
+  const seen = []
+  const drive = async (id) => {
+    const key = sessionKeyFor(id)
+    for await (const _ of scopeSession(key, between(adapter(seen)))) {
+      // the consumer sits OUTSIDE the scope, exactly as the loop does
+      assert.equal(currentSessionKey(), "process")
+    }
+  }
+  await Promise.all([drive("sess-a"), drive("sess-b")])
+  assert.deepEqual([...seen].sort(), ["sess-a", "sess-b"])
+})
+
+test("the obvious scoping is what this replaces: it sees nothing", async () => {
+  // Kept as an executable statement of WHY `scopeSession` pulls rather than
+  // wraps. `als.run(key, () => next())` scopes the CONSTRUCTION of the
+  // downstream iterable; the generator body runs when the consumer pulls,
+  // after that scope has exited. Every session would collapse onto one key.
+  const storage = new AsyncLocalStorage()
+  const seen = []
+  const naive = async (id) => {
+    const it = storage.run(id, () => between(adapter(seen)))
+    for await (const _ of it) { /* drain */ }
+  }
+  await Promise.all([naive("sess-a"), naive("sess-b")])
+  assert.deepEqual(seen, ["process", "process"], "the naive form loses the key — this is the bug, pinned")
+})
+
+test("a model call outside the loop shares the process-wide key", () => {
+  assert.equal(sessionKeyFor(undefined), "process")
+  assert.equal(sessionKeyFor(null), "process")
+  assert.equal(sessionKeyFor("sess-1"), "sess-1")
+  assert.equal(currentSessionKey(), "process")
+})
+
+test("breaking out of the stream tears the adapter down", async () => {
+  let closed = false
+  async function* closing() {
+    try {
+      yield 1
+      yield 2
+    } finally {
+      closed = true
+    }
+  }
+  for await (const _ of scopeSession("sess-a", closing())) break
+  assert.equal(closed, true, "an abandoned stream must release the underlying response")
+})

--- a/integrations/agent/local-redaction/src/protocol.ts
+++ b/integrations/agent/local-redaction/src/protocol.ts
@@ -18,6 +18,10 @@ export type ModelProtocol = "openai.chat" | "anthropic.messages" | "openai.respo
 export const DEFAULT_MODEL_HOSTS: readonly string[] = [
   "api.openai.com",
   "api.anthropic.com",
+  // Codex's backend when the user is signed in with ChatGPT rather than an
+  // API key (`CHATGPT_CODEX_BASE_URL` in `codex-rs/model-provider-info`).
+  // It speaks `openai.responses` like the API-key endpoint does.
+  "chatgpt.com",
   "openrouter.ai",
   "generativelanguage.googleapis.com",
 ]

--- a/integrations/agent/ogr-local/README.md
+++ b/integrations/agent/ogr-local/README.md
@@ -1,0 +1,125 @@
+# @openguardrails/ogr-local
+
+**Local secrets redaction for harnesses whose plugins run outside the agent's
+process — [Claude Code](../claude-code) and [OpenAI Codex](../codex).**
+
+Every credential in the outbound model request is replaced with
+`${OGR_SECRET_n}` **on this machine**. The runtime judges the placeholder, the
+model provider is given the placeholder, and the real value is put back into
+the reply's tool-call arguments — locally — so the tool still runs with a
+working credential. Same contract as the in-process masking the other
+integrations do ([OGR 1.4](../../../specification/local-redaction.md)), at a
+different vantage.
+
+## Do you need this?
+
+**Probably not.** If your harness loads a plugin *inside* the agent's process
+— hermes, opencode, openclaw, dsh — that plugin installs an in-process
+`fetch` interceptor and this package is not involved. No port, no lifecycle,
+no base URL to change, and nothing left running when the harness exits.
+
+Two harnesses cannot do that, and that is the entire reason this exists:
+
+| harness | why the interceptor is impossible |
+|---|---|
+| **Claude Code** | hooks are separate **processes**; there is no seam inside the agent to install anything on |
+| **Codex** | the host is **Rust**, and its hooks are separate processes too |
+
+For those, the next vantage down is a socket in front of the harness.
+
+## Install
+
+```sh
+npm i -g @openguardrails/ogr-local
+```
+
+The harness plugins start it for you from their `SessionStart` hook. You only
+run it by hand to check on it:
+
+```sh
+ogr-local status
+```
+
+## Wiring
+
+**The upstream travels in the path**, which is what lets one daemon on one
+port serve harnesses that talk to different providers:
+
+```sh
+# Claude Code — settings.json
+"env": { "ANTHROPIC_BASE_URL": "http://127.0.0.1:8787/https/api.anthropic.com" }
+
+# Codex — ~/.codex/config.toml (ChatGPT sign-in)
+openai_base_url = "http://127.0.0.1:8787/https/chatgpt.com/backend-api/codex"
+# Codex — ~/.codex/config.toml (API key)
+openai_base_url = "http://127.0.0.1:8787/https/api.openai.com/v1"
+
+# or ask:
+ogr-local base-url https://api.anthropic.com
+```
+
+Both harnesses resolve their provider URL **statically at startup** — Claude
+Code from `settings.json`, Codex from `config.toml` — so neither can be handed
+an ephemeral port, and a fixed port *per upstream* would mean one listener per
+provider, each with its own lifecycle. Encoding the upstream in the base URL
+the harness is already configured with collapses that to one port.
+
+⚠️ **A hook cannot set these for you.** A hook is a child process; the
+harness read its own environment long before. The `SessionStart` hooks start
+the daemon and then *check* the setting, so the one failure that would
+otherwise be silent — daemon healthy, harness talking straight to the
+provider, nothing masked — is said out loud.
+
+## Commands
+
+| | |
+|---|---|
+| `ogr-local ensure` | make sure a daemon is listening; print its URL. Idempotent — the port is the lock, and the check is a live request, so a stale record cannot lie |
+| `ogr-local serve` | run in the foreground (what `ensure` spawns) |
+| `ogr-local status` | ruleset, session count, and what has been masked |
+| `ogr-local base-url <url>` | the base URL to point a harness at, for one upstream |
+
+Configuration is environment, shared with the rest of the OGR integrations:
+`OGR_API_KEY` (required — the ruleset is your organization's),
+`OGR_RUNTIME_URL`, `OGR_LOCAL_PORT` (8787), `OGR_RULES_CACHE`,
+`OGR_FAIL_MODE`, `OGR_LOCAL_IDLE_MS` (6h).
+
+## What it deliberately is not
+
+- **Not an auth boundary.** Your `Authorization` / `x-api-key` is forwarded
+  byte for byte and never read. The proxy holds no credential and mints none
+   — a process that could answer *for* you is a far worse thing to leave
+  listening than one that can only rewrite a body.
+- **Not a policy engine.** Verdicts stay with the harness's OGR hooks. This
+  is a masking seam, not a second enforcement point.
+- **Not an open proxy.** The path may only name a known model API host; add
+  your own gateway with `--host`. Without that bound, a general-purpose
+  forwarder would be listening on loopback for every process on the machine.
+- **There is no `/__ogr/restore`.** `/__ogr/mask` exists so a hook's own
+  event carries the same tokens the provider was given; the reverse would
+  hand any local process the plaintext of every secret the session has seen.
+- **It refuses to start without an API key.** With no key there is no
+  ruleset, so it would forward everything unmasked while a harness pointed at
+  it looked protected. Better to not be listening at all.
+
+## Honest limits
+
+- **If the daemon is down, the harness cannot reach its provider.** That is
+  the cost of a base-URL redirect, and it is why `ensure` runs on every
+  session start and why the idle timeout is hours rather than minutes. The
+  in-process interceptor has no equivalent failure — one more reason to
+  prefer it wherever a plugin can run in-process.
+- **Replies are requested uncompressed.** A gzipped body is one no tool call
+  can be restored out of, and forwarding it would look exactly like a reply
+  with nothing to restore.
+- **One map per session key**, read from the request's own `metadata.user_id`
+  / `user` where the harness stamps one (Claude Code does), else one key for
+  the process.
+
+## Development
+
+```sh
+npm install     # from the repo root (npm workspace)
+npm run build
+npm test
+```

--- a/integrations/agent/ogr-local/package.json
+++ b/integrations/agent/ogr-local/package.json
@@ -1,0 +1,59 @@
+{
+  "name": "@openguardrails/ogr-local",
+  "version": "0.1.0",
+  "description": "The local masking proxy for agent harnesses with no in-process plugin seam — Claude Code and Codex. Masks every credential in the outbound model request on the host, restores it into the reply's tool-call arguments, and lets the harness's OGR hooks report the same tokens the provider was given (OGR 1.4).",
+  "type": "module",
+  "license": "Apache-2.0",
+  "author": "OpenGuardrails",
+  "bin": {
+    "ogr-local": "./dist/cli.js"
+  },
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "files": [
+    "dist",
+    "src",
+    "README.md"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "pretest": "npm run build",
+    "test": "node --test tests/*.spec.mjs",
+    "clean": "rm -rf dist"
+  },
+  "keywords": [
+    "proxy",
+    "redaction",
+    "secrets",
+    "claude-code",
+    "codex",
+    "ai",
+    "agent",
+    "security",
+    "guardrails",
+    "ogr",
+    "openguardrails"
+  ],
+  "dependencies": {
+    "@openguardrails/local-redaction": "^0.1.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22",
+    "typescript": "^5.7.0"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/openguardrails/openguardrails.git",
+    "directory": "integrations/agent/ogr-local"
+  },
+  "homepage": "https://openguardrails.com",
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/integrations/agent/ogr-local/src/cli.ts
+++ b/integrations/agent/ogr-local/src/cli.ts
@@ -1,0 +1,111 @@
+#!/usr/bin/env node
+/**
+ * `ogr-local` — the command a `SessionStart` hook runs.
+ *
+ *   ogr-local ensure          make sure a daemon is listening; print its URL
+ *   ogr-local serve           run the daemon in the foreground (what `ensure` spawns)
+ *   ogr-local status          what the running daemon has masked
+ *   ogr-local base-url <url>  the base URL to point a harness at, for one upstream
+ *
+ * ⚠️ Every exit path is 0 except an outright usage error. A masking proxy
+ * that fails a harness's session start because it could not come up has
+ * turned a redaction outage into an inability to work — the harness must
+ * carry on, unprotected and loudly, exactly as it did before this existed.
+ */
+import { LocalRedactor } from "@openguardrails/local-redaction"
+
+import { baseUrlFor, ensure, port, probe } from "./daemon.js"
+import { startProxy } from "./server.js"
+
+const argv = process.argv.slice(2)
+const flag = (name: string): string | undefined => {
+  const at = argv.indexOf(`--${name}`)
+  return at !== -1 ? argv[at + 1] : undefined
+}
+const has = (name: string): boolean => argv.includes(`--${name}`)
+
+const log = { info: (m: string) => console.error(m), warn: (m: string) => console.error(m) }
+
+async function serve(): Promise<void> {
+  const runtimeUrl = flag("runtime") ?? process.env["OGR_RUNTIME_URL"] ?? "https://openguardrails.com"
+  const apiKey = flag("api-key") ?? process.env["OGR_API_KEY"] ?? ""
+  if (!apiKey) {
+    // Refused rather than started: with no key there is no ruleset, so the
+    // daemon would forward every request unmasked while a harness pointed
+    // at it looked protected. Better to not be listening at all.
+    console.error("[ogr-local] no OGR_API_KEY — refusing to start a proxy that could not mask anything")
+    process.exit(1)
+  }
+  const redactor = new LocalRedactor({
+    source: () => ({ runtimeUrl, apiKey }),
+    ...(process.env["OGR_RULES_CACHE"] ? { cachePath: process.env["OGR_RULES_CACHE"]! } : {}),
+    log,
+  })
+  await redactor.start()
+  // The interceptor's `sawTraffic` proof does not apply here: this process
+  // IS the traffic path, so a request that reaches it has been masked by
+  // definition. Nothing else could be listening on this port and forward.
+  redactor.fallbackActive = true
+
+  const idleMs = Number(flag("idle-ms") ?? process.env["OGR_LOCAL_IDLE_MS"] ?? 6 * 60 * 60 * 1000)
+  const proxy = await startProxy({
+    redactor,
+    ...(flag("upstream") ? { upstream: flag("upstream")! } : {}),
+    ...(flag("host") ? { hosts: flag("host")!.split(",").map((h) => h.trim()).filter(Boolean) } : {}),
+    port: Number(flag("port") ?? port()),
+    failClosed: has("fail-closed") || process.env["OGR_FAIL_MODE"] === "closed",
+    idleMs: Number.isFinite(idleMs) ? idleMs : 0,
+    log,
+  })
+  log.info(`[ogr-local] listening on ${proxy.url} — ruleset ${redactor.rulesetId || "(none)"}`)
+
+  // Refresh the ruleset on the same cadence a plugin's heartbeat would.
+  const timer = setInterval(() => void redactor.refresh(), 60_000)
+  timer.unref?.()
+
+  for (const signal of ["SIGINT", "SIGTERM"] as const) {
+    process.on(signal, () => void proxy.close().then(() => process.exit(0)))
+  }
+}
+
+async function main(): Promise<void> {
+  switch (argv[0]) {
+    case "serve":
+      return serve()
+    case "ensure": {
+      const url = await ensure({
+        ...(flag("port") ? { port: Number(flag("port")) } : {}),
+        args: [
+          ...(flag("upstream") ? ["--upstream", flag("upstream")!] : []),
+          ...(flag("host") ? ["--host", flag("host")!] : []),
+          ...(has("fail-closed") ? ["--fail-closed"] : []),
+        ],
+      })
+      if (url) console.log(url)
+      else console.error("[ogr-local] could not start a masking proxy — the harness will run unprotected")
+      return
+    }
+    case "status": {
+      const s = await probe(flag("port") ? Number(flag("port")) : undefined)
+      console.log(JSON.stringify(s ?? { ok: false }, null, 2))
+      return
+    }
+    case "base-url": {
+      const upstream = argv[1]
+      if (!upstream) {
+        console.error("usage: ogr-local base-url <https://api.example.com[/prefix]>")
+        process.exit(2)
+      }
+      console.log(baseUrlFor(upstream, flag("port") ? Number(flag("port")) : undefined))
+      return
+    }
+    default:
+      console.error("usage: ogr-local <ensure|serve|status|base-url> [--port N] [--upstream URL] [--host a,b] [--fail-closed]")
+      process.exit(2)
+  }
+}
+
+void main().catch((err: unknown) => {
+  console.error(`[ogr-local] ${String(err)}`)
+  process.exit(1)
+})

--- a/integrations/agent/ogr-local/src/daemon.ts
+++ b/integrations/agent/ogr-local/src/daemon.ts
@@ -1,0 +1,119 @@
+/**
+ * Starting the proxy once, from a hook that runs on every session.
+ *
+ * A `SessionStart` hook fires for every new conversation and for every
+ * `--resume`, so "start the proxy" has to mean "make sure exactly one is
+ * listening" — and it has to be safe when two harnesses fire at the same
+ * instant. The answer is the port itself: a daemon is IDENTIFIED by the port
+ * it holds, `ensure()` asks that port whether an `ogr-local` is already
+ * there, and only spawns when nothing answers. A stale record cannot lie,
+ * because the check is a live request rather than a pid or a lock file.
+ *
+ * ⚠️ THE PORT IS FIXED, AND THAT IS FORCED. Both harnesses configure their
+ * provider base URL statically — Claude Code in `settings.json`'s `env`,
+ * Codex in `config.toml` — so neither can be handed an ephemeral port. One
+ * fixed port serves every upstream because the upstream travels in the path
+ * (`server.ts`, `upstreamFor`).
+ */
+import { spawn } from "node:child_process"
+import { openSync } from "node:fs"
+import { mkdir } from "node:fs/promises"
+import { homedir } from "node:os"
+import { join } from "node:path"
+import { fileURLToPath } from "node:url"
+
+/** The port `ANTHROPIC_BASE_URL` and `openai_base_url` are written against. */
+export const DEFAULT_PORT = 8787
+
+export const port = (): number => {
+  const raw = process.env["OGR_LOCAL_PORT"]
+  const n = raw ? Number(raw) : NaN
+  return Number.isInteger(n) && n > 0 && n < 65536 ? n : DEFAULT_PORT
+}
+
+/** `~/.openguardrails` — shared with the ruleset cache. */
+export const stateDir = (): string => join(homedir(), ".openguardrails")
+
+export interface Status {
+  ok: true
+  upstream: string | null
+  ruleset: string
+  masking: boolean
+  sessions: number
+  counters: Record<string, number>
+}
+
+/** Ask the port whether an `ogr-local` is behind it. Never throws. */
+export async function probe(p = port(), timeoutMs = 500): Promise<Status | null> {
+  const controller = new AbortController()
+  const timer = setTimeout(() => controller.abort(), timeoutMs)
+  try {
+    const res = await fetch(`http://127.0.0.1:${p}/__ogr/status`, { signal: controller.signal })
+    if (!res.ok) return null
+    const body = (await res.json()) as Status
+    return body?.ok === true ? body : null
+  } catch {
+    return null
+  } finally {
+    clearTimeout(timer)
+  }
+}
+
+export interface EnsureOptions {
+  port?: number
+  /** How long to wait for a freshly spawned daemon to answer (default 8s). */
+  waitMs?: number
+  /** Extra argv for the spawned daemon. */
+  args?: readonly string[]
+  /** Where the daemon's stderr goes (default `~/.openguardrails/ogr-local.log`). */
+  logPath?: string
+}
+
+/**
+ * The URL a harness should be pointed at, starting a daemon if none answers.
+ *
+ * Returns `null` when one could not be started — the CALLER decides what
+ * that means, and for both harnesses the answer is "say so and carry on
+ * unprotected". A hook that failed the session because a masking proxy did
+ * not come up would turn a redaction outage into an inability to work.
+ */
+export async function ensure(opts: EnsureOptions = {}): Promise<string | null> {
+  const p = opts.port ?? port()
+  if (await probe(p)) return `http://127.0.0.1:${p}`
+
+  await mkdir(stateDir(), { recursive: true }).catch(() => {})
+  const logPath = opts.logPath ?? join(stateDir(), "ogr-local.log")
+  let out = "ignore" as "ignore" | number
+  try {
+    out = openSync(logPath, "a")
+  } catch {
+    /* a log we cannot open is not a reason to skip the mask */
+  }
+
+  const entry = fileURLToPath(new URL("./cli.js", import.meta.url))
+  const child = spawn(process.execPath, [entry, "serve", "--port", String(p), ...(opts.args ?? [])], {
+    detached: true,
+    // ⚠️ stdin must be `ignore`, not inherited: a detached child holding the
+    // harness's stdin steals the user's keystrokes on some terminals.
+    stdio: ["ignore", out, out],
+    env: process.env,
+  })
+  child.unref()
+
+  // Poll rather than sleep: the hook is holding the session open, and the
+  // difference between 60ms and a fixed one-second sleep is felt on every
+  // `--resume`.
+  const deadline = Date.now() + (opts.waitMs ?? 8000)
+  for (;;) {
+    if (await probe(p, 300)) return `http://127.0.0.1:${p}`
+    if (Date.now() > deadline) return null
+    await new Promise((r) => setTimeout(r, 60))
+  }
+}
+
+/** The base URL to configure a harness with, for one upstream. */
+export function baseUrlFor(upstream: string, p = port()): string {
+  const u = new URL(upstream)
+  const path = u.pathname === "/" ? "" : u.pathname.replace(/\/$/, "")
+  return `http://127.0.0.1:${p}/${u.protocol.replace(":", "")}/${u.host}${path}`
+}

--- a/integrations/agent/ogr-local/src/index.ts
+++ b/integrations/agent/ogr-local/src/index.ts
@@ -1,0 +1,14 @@
+/**
+ * `@openguardrails/ogr-local` — local secrets redaction for harnesses whose
+ * plugins run OUTSIDE the agent's process.
+ *
+ * hermes, opencode, openclaw and dsh install an in-process HTTP interceptor
+ * (`@openguardrails/local-redaction`) and need nothing here. Claude Code and
+ * Codex cannot: their hooks are separate processes — Codex's host is Rust —
+ * so the seam moves one layer out, to a loopback proxy the harness's
+ * provider base URL points at. Same ruleset, same session maps, same
+ * `${OGR_SECRET_n}` contract; a different vantage.
+ */
+export { Pipe, DEFAULT_SESSION, type Masked, type PipeOptions } from "./pipe.js"
+export { startProxy, upstreamFor, type ProxyOptions, type RunningProxy } from "./server.js"
+export { baseUrlFor, DEFAULT_PORT, ensure, port, probe, stateDir, type EnsureOptions, type Status } from "./daemon.js"

--- a/integrations/agent/ogr-local/src/pipe.ts
+++ b/integrations/agent/ogr-local/src/pipe.ts
@@ -1,0 +1,161 @@
+/**
+ * The masking pipe: one model request in, one masked request out; one reply
+ * back, tool-call arguments restored.
+ *
+ * This is the same work `@openguardrails/local-redaction`'s in-process
+ * interceptor does, at the one vantage a harness with no plugin seam leaves
+ * open — a socket in front of it. The interceptor wraps `fetch` inside the
+ * agent's own process; this wraps nothing and owns no process, so it is
+ * expressed as a pure-ish pair of functions over bodies and a streaming
+ * transformer, and the transport lives in `server.ts`.
+ *
+ * ⚠️ Kept deliberately thin, and deliberately NOT a fork of the
+ * interceptor's `Core`: both must agree about what a model call is, which
+ * protocol a body speaks, and where a tool call's arguments live, so both
+ * read those answers from the shared library rather than from a local copy.
+ * The one thing this module knows that the interceptor does not is that
+ * there is an UPSTREAM — a real provider the request is on its way to.
+ */
+import {
+  createSseRestorer,
+  restoreResponseBody,
+  sniffProtocol,
+  stampedSession,
+  type LocalRedactor,
+  type ModelProtocol,
+  type RedactionReport,
+} from "@openguardrails/local-redaction"
+
+/** What a masked request became, and what the reply half needs to undo it. */
+export interface Masked {
+  protocol: ModelProtocol
+  session: string
+  body: string
+  /** Whether anything actually changed — the caller may forward the original bytes when not. */
+  changed: boolean
+  minted: number
+}
+
+export interface PipeOptions {
+  redactor: LocalRedactor
+  /**
+   * Derives the session key from a request. The default reads the body's own
+   * stamp — Anthropic and OpenAI both carry a caller-chosen `metadata.user_id`
+   * / `user`, and Claude Code puts a per-session value there — falling back
+   * to one key for the whole process.
+   */
+  sessionKey?: (req: { url: URL; body: unknown; headers: Headers }) => string
+  /** Extra hostnames to treat as a model API (a self-hosted gateway). */
+  hosts?: readonly string[]
+  log?: { info(m: string): void; warn(m: string): void }
+}
+
+/** One key for a proxy nobody stamped a session onto. */
+export const DEFAULT_SESSION = "process"
+
+export class Pipe {
+  readonly counters = { requests: 0, streams: 0, restored: 0, passed: 0, minted: 0 }
+  private readonly sessions = new Set<string>()
+
+  constructor(private readonly opts: PipeOptions) {}
+
+  get redactor(): LocalRedactor {
+    return this.opts.redactor
+  }
+
+  /**
+   * Mask one outbound request, or answer `null` for "this is not a model
+   * call — forward it untouched".
+   *
+   * ⚠️ A body that does not parse as JSON, or does not sniff as one of the
+   * three protocols, is passed through VERBATIM. That is not laziness: the
+   * harness talks to its provider about more than completions (token counts,
+   * model lists, file uploads), and a proxy that rewrote those would break
+   * the harness while protecting nothing.
+   */
+  mask(url: URL, headers: Headers, text: string): Masked | null {
+    let body: unknown
+    try {
+      body = JSON.parse(text)
+    } catch {
+      return null
+    }
+    const protocol = sniffProtocol(body, url)
+    if (!protocol) return null
+
+    const session = this.opts.sessionKey
+      ? this.opts.sessionKey({ url, body, headers })
+      : (stampedSession(body) ?? DEFAULT_SESSION)
+    this.sessions.add(session)
+
+    const masked = this.redactor.maskValue(session, body)
+    this.counters.requests += 1
+    this.counters.minted += masked.minted.length
+    return {
+      protocol,
+      session,
+      body: masked.changed ? JSON.stringify(masked.value) : text,
+      changed: masked.changed,
+      minted: masked.minted.length,
+    }
+  }
+
+  /** Put the values back into a buffered reply's tool-call arguments. */
+  restore(plan: Masked, text: string): string {
+    const r = restoreResponseBody(plan.protocol, text, this.redactor.session(plan.session))
+    if (!r) return text
+    if (r.changed) this.counters.restored += 1
+    if (r.unresolved.length) {
+      this.opts.log?.warn(
+        `[ogr-local] ${r.unresolved.length} placeholder(s) in a tool call had no value to restore — the model invented or altered a token`,
+      )
+    }
+    return r.body
+  }
+
+  /** The same, frame by frame, for an SSE reply. */
+  streamRestorer(plan: Masked): { feed(chunk: string): string; end(): string } {
+    this.counters.streams += 1
+    let counted = false
+    const inner = createSseRestorer(plan.protocol, this.redactor.session(plan.session), {
+      onUnresolved: (tokens) =>
+        this.opts.log?.warn(`[ogr-local] ${tokens.length} placeholder(s) in a streamed tool call had no value to restore`),
+    })
+    return {
+      feed: (chunk) => {
+        const out = inner.feed(chunk)
+        if (!counted && out !== chunk) {
+          counted = true
+          this.counters.restored += 1
+        }
+        return out
+      },
+      end: () => inner.end(),
+    }
+  }
+
+  /**
+   * The report for a step, drained across every session this proxy has
+   * masked under — the harness's hook cannot know which key its own step
+   * was filed under, because the key came off the request body the hook
+   * never saw.
+   */
+  report(session?: string): RedactionReport | undefined {
+    if (!this.redactor.masking) return undefined
+    const keys = session ? [session] : [...this.sessions]
+    if (keys.length === 0) return { ruleset: this.redactor.rulesetId, masked: [] }
+    const masked: RedactionReport["masked"] = []
+    let ruleset = this.redactor.rulesetId
+    for (const key of keys) {
+      const part = this.redactor.report(key)
+      if (!part) continue
+      ruleset = part.ruleset
+      masked.push(...part.masked)
+    }
+    return { ruleset, masked }
+  }
+
+  knownSessions(): string[] {
+    return [...this.sessions]
+  }
+}

--- a/integrations/agent/ogr-local/src/server.ts
+++ b/integrations/agent/ogr-local/src/server.ts
@@ -1,0 +1,344 @@
+/**
+ * The proxy itself: a loopback HTTP server the harness's provider base URL
+ * points at, forwarding to the real provider with the request masked and the
+ * reply's tool-call arguments restored.
+ *
+ * ⚠️⚠️ **THIS EXISTS BECAUSE TWO HARNESSES HAVE NO IN-PROCESS SEAM, AND FOR
+ * NO OTHER REASON.** Claude Code and Codex expose hooks as separate
+ * PROCESSES — Codex's host is not even JavaScript — so the interceptor that
+ * masks inside hermes, opencode, openclaw and dsh cannot be installed there.
+ * A socket in front of the harness is the next vantage down. Anything with a
+ * plugin that runs in the agent's own process must use the interceptor
+ * instead: it needs no port, no lifecycle and no base-URL change, and it
+ * cannot be left running after the harness exits.
+ *
+ * What it does NOT do, on purpose:
+ *
+ * - **It holds no credential and mints none.** The harness's own
+ *   `Authorization` (or `x-api-key`) is forwarded byte for byte and never
+ *   read. The proxy is not an auth boundary and must never become one — a
+ *   process that could answer for the user is a far worse thing to leave
+ *   listening than one that can only rewrite a body.
+ * - **It answers no `/restore`.** `/__ogr/mask` is offered to the harness's
+ *   hooks so their events carry the same tokens the provider was given;
+ *   the reverse would turn a loopback port into an oracle that hands any
+ *   local process the plaintext of every secret this session has seen.
+ * - **It does not judge.** Verdicts stay with the harness's OGR hooks. This
+ *   is a masking seam, not a second enforcement point.
+ */
+import { createServer, type IncomingMessage, type Server, type ServerResponse } from "node:http"
+import { Readable } from "node:stream"
+
+import { isModelHost, LocalRedactor } from "@openguardrails/local-redaction"
+
+import { Pipe, type PipeOptions } from "./pipe.js"
+
+/** Headers a proxy must not copy through — they describe THIS hop, not the next. */
+const HOP_BY_HOP = new Set([
+  "connection",
+  "keep-alive",
+  "proxy-authenticate",
+  "proxy-authorization",
+  "te",
+  "trailer",
+  "transfer-encoding",
+  "upgrade",
+  "host",
+  "content-length",
+])
+
+/**
+ * ⚠️ `accept-encoding` is dropped on the way UP so the provider answers in
+ * plain text. A gzipped reply is one this proxy cannot restore a tool call
+ * out of, and silently forwarding it would look exactly like a reply with
+ * nothing to restore. Compression between a loopback socket and a provider
+ * is not worth a failure mode that quiet.
+ */
+const DROP_UPSTREAM = new Set([...HOP_BY_HOP, "accept-encoding"])
+
+export interface ProxyOptions extends Omit<PipeOptions, "redactor"> {
+  /**
+   * Where the real provider is when the request does not name one, e.g.
+   * `https://api.anthropic.com`. Optional: the ordinary wiring puts the
+   * upstream in the PATH (see {@link upstreamFor}), which is what lets one
+   * daemon on one port serve harnesses that talk to different providers.
+   */
+  upstream?: string
+  redactor: LocalRedactor
+  /** Refuse a model request when no ruleset is in hand (default: forward it, loudly). */
+  failClosed?: boolean
+  /** Shut down after this many ms with no request (0 = never). */
+  idleMs?: number
+}
+
+export interface RunningProxy {
+  url: string
+  port: number
+  pipe: Pipe
+  close(): Promise<void>
+}
+
+const nowMs = (): number => Date.now()
+
+const trimSlash = (u: string): string => (u.endsWith("/") ? u.slice(0, -1) : u)
+
+/**
+ * Where this request is really going.
+ *
+ * ⚠️⚠️ **THE UPSTREAM IS IN THE PATH, AND THAT IS WHAT MAKES ONE DAEMON
+ * ENOUGH.** Both harnesses this proxy exists for configure their provider
+ * base URL STATICALLY — Claude Code through `settings.json`'s `env` block,
+ * Codex through `openai_base_url` in `config.toml` — so neither can be told
+ * about an ephemeral port, and a fixed port per upstream would mean one
+ * listener per provider, each needing its own lifecycle. Encoding the
+ * upstream in the base URL the harness is already configured with collapses
+ * all of that to one port:
+ *
+ *     ANTHROPIC_BASE_URL=http://127.0.0.1:8787/https/api.anthropic.com
+ *     openai_base_url   ="http://127.0.0.1:8787/https/chatgpt.com/backend-api/codex"
+ *
+ * `/https/<host>/<rest>` rather than a query parameter or a header, because
+ * a base URL is the ONE thing both harnesses let an operator set, and every
+ * path they append lands after it untouched.
+ */
+export function upstreamFor(
+  url: URL,
+  fallback: string | null,
+): { base: string; path: string; host: string; hostname: string } | null {
+  const m = /^\/(https?)\/([^/]+)(\/.*)?$/.exec(url.pathname)
+  if (m) {
+    const [, scheme, host, rest] = m
+    // ⚠️ `host` is the AUTHORITY (it may carry a port) and `hostname` is what
+    // the allowlist compares. Passing the authority to `isModelHost` looks
+    // right and refuses every upstream on a non-default port — which is
+    // every test double and every self-hosted gateway.
+    return {
+      base: `${scheme}://${host}`,
+      path: rest ?? "/",
+      host: host!,
+      hostname: new URL(`${scheme}://${host}`).hostname,
+    }
+  }
+  if (!fallback) return null
+  const u = new URL(fallback)
+  return { base: fallback, path: url.pathname, host: u.host, hostname: u.hostname }
+}
+
+export async function startProxy(opts: ProxyOptions & { port?: number; host?: string }): Promise<RunningProxy> {
+  const log = opts.log ?? { info: (m: string) => console.error(m), warn: (m: string) => console.error(m) }
+  const pipe = new Pipe({ ...opts, log })
+  const fallback = opts.upstream ? trimSlash(opts.upstream) : null
+  let lastActivity = nowMs()
+
+  const server = createServer((req, res) => {
+    lastActivity = nowMs()
+    // ⚠️ A daemon outlives the request that killed it. An `error` event with
+    // no listener — the client hanging up mid-stream is the ordinary case —
+    // is an uncaught exception, and taking the proxy down takes the harness's
+    // model access with it.
+    req.on("error", () => {})
+    res.on("error", () => {})
+    handle(req, res).catch((err: unknown) => {
+      log.warn(`[ogr-local] ${String(err)}`)
+      if (!res.headersSent) res.writeHead(502, { "content-type": "application/json" })
+      res.end(JSON.stringify({ error: "ogr_local_proxy_failed", detail: String(err) }))
+    })
+  })
+
+  async function readBody(req: IncomingMessage): Promise<Buffer> {
+    const parts: Buffer[] = []
+    for await (const chunk of req) parts.push(chunk as Buffer)
+    return Buffer.concat(parts)
+  }
+
+  async function handle(req: IncomingMessage, res: ServerResponse): Promise<void> {
+    const url = new URL(req.url ?? "/", `http://${req.headers.host ?? "127.0.0.1"}`)
+    if (url.pathname.startsWith("/__ogr/")) return control(req, res, url)
+
+    const raw = await readBody(req)
+    const route = upstreamFor(url, fallback)
+    if (!route) {
+      return refuse(res, 404, "ogr_local_no_upstream", "no upstream in the path and none configured — see the README's base-URL wiring")
+    }
+    if (!isModelHost(route.hostname, opts.hosts)) {
+      // ⚠️ THE ALLOWLIST IS WHAT KEEPS A PATH-ADDRESSED PROXY FROM BEING AN
+      // OPEN ONE. Putting the upstream in the URL is what lets one daemon
+      // serve every harness; without a bound on where that URL may point,
+      // any process on this machine would have a general-purpose forwarder
+      // listening on loopback. It may only reach model APIs.
+      return refuse(res, 403, "ogr_local_upstream_refused", `${route.hostname} is not a known model API host (add it with --host)`)
+    }
+    const target = new URL(route.base + route.path + url.search)
+    const headers = new Headers()
+    for (const [k, v] of Object.entries(req.headers)) {
+      if (v === undefined || DROP_UPSTREAM.has(k.toLowerCase())) continue
+      headers.set(k, Array.isArray(v) ? v.join(", ") : v)
+    }
+
+    // -- the request half --
+    let plan = null as ReturnType<Pipe["mask"]>
+    let out: Buffer | undefined = raw.length > 0 ? raw : undefined
+    if (raw.length > 0) {
+      if (!pipe.redactor.ready) {
+        // No ruleset: the honest choices are "forward, loudly" and "refuse".
+        // Forwarding is the default because a proxy that stops the harness
+        // is a proxy nobody keeps installed — and an unmasked request is
+        // exactly what the harness did before this existed.
+        if (opts.failClosed && looksLikeModelCall(raw)) {
+          res.writeHead(503, { "content-type": "application/json" })
+          res.end(JSON.stringify({ error: "ogr_local_unprotected", detail: "no secret ruleset in hand and the deployment is fail-closed" }))
+          return
+        }
+        pipe.redactor.warnUnprotected("this model request")
+      }
+      plan = pipe.mask(target, headers, raw.toString("utf8"))
+      if (plan) out = Buffer.from(plan.body, "utf8")
+      else pipe.counters.passed += 1
+    }
+    if (out) headers.set("content-length", String(out.byteLength))
+
+    const upstreamRes = await fetch(target, {
+      method: req.method ?? "GET",
+      headers,
+      ...(out ? { body: out } : {}),
+      redirect: "manual",
+    })
+
+    // -- the reply half --
+    const replyHeaders: Record<string, string> = {}
+    upstreamRes.headers.forEach((v, k) => {
+      if (!HOP_BY_HOP.has(k.toLowerCase())) replyHeaders[k] = v
+    })
+    // ⚠️ `fetch` decompresses transparently, so the bytes we are about to
+    // write are PLAIN whatever the provider's header says. Forwarding a
+    // `content-encoding: gzip` over plaintext gives the harness a body it
+    // cannot decode — an integration that looks broken for a reason nowhere
+    // near the mask.
+    delete replyHeaders["content-encoding"]
+    const type = upstreamRes.headers.get("content-type") ?? ""
+
+    if (!plan || !upstreamRes.body) {
+      // Nothing to restore into: stream the provider's answer through.
+      delete replyHeaders["content-length"]
+      res.writeHead(upstreamRes.status, replyHeaders)
+      if (upstreamRes.body) await pump(upstreamRes.body, res)
+      else res.end()
+      return
+    }
+
+    if (type.includes("text/event-stream")) {
+      delete replyHeaders["content-length"]
+      res.writeHead(upstreamRes.status, replyHeaders)
+      const restorer = pipe.streamRestorer(plan)
+      const decoder = new TextDecoder()
+      for await (const chunk of upstreamRes.body as unknown as AsyncIterable<Uint8Array>) {
+        res.write(restorer.feed(decoder.decode(chunk, { stream: true })))
+      }
+      const tail = restorer.end()
+      if (tail) res.write(tail)
+      res.end()
+      return
+    }
+
+    const text = await upstreamRes.text()
+    const restored = pipe.restore(plan, text)
+    const bytes = Buffer.from(restored, "utf8")
+    replyHeaders["content-length"] = String(bytes.byteLength)
+    res.writeHead(upstreamRes.status, replyHeaders)
+    res.end(bytes)
+  }
+
+  function refuse(res: ServerResponse, status: number, error: string, detail: string): void {
+    const bytes = Buffer.from(JSON.stringify({ error, detail }), "utf8")
+    res.writeHead(status, { "content-type": "application/json", "content-length": String(bytes.byteLength) })
+    res.end(bytes)
+  }
+
+  /** A JSON body carrying `messages`/`input`/`instructions` — enough for the fail-closed gate. */
+  function looksLikeModelCall(raw: Buffer): boolean {
+    try {
+      const b = JSON.parse(raw.toString("utf8")) as Record<string, unknown>
+      return b["messages"] !== undefined || b["input"] !== undefined || b["instructions"] !== undefined
+    } catch {
+      return false
+    }
+  }
+
+  async function pump(body: ReadableStream<Uint8Array>, res: ServerResponse): Promise<void> {
+    await new Promise<void>((resolve, reject) => {
+      Readable.fromWeb(body as never)
+        .on("error", reject)
+        .on("end", resolve)
+        .pipe(res)
+    })
+  }
+
+  /**
+   * The loopback control surface. Two routes and no more, both read-only
+   * about secrets: `status` for a hook that wants to know whether anything
+   * is masking, and `mask` so a hook's OWN event carries the same tokens
+   * the provider was given (D6 — the OGR client is an egress too).
+   */
+  async function control(req: IncomingMessage, res: ServerResponse, url: URL): Promise<void> {
+    const reply = (status: number, payload: unknown): void => {
+      const bytes = Buffer.from(JSON.stringify(payload), "utf8")
+      res.writeHead(status, { "content-type": "application/json", "content-length": String(bytes.byteLength) })
+      res.end(bytes)
+    }
+    if (url.pathname === "/__ogr/status") {
+      return reply(200, {
+        ok: true,
+        upstream: fallback,
+        ruleset: pipe.redactor.rulesetId,
+        masking: pipe.redactor.masking && pipe.redactor.ready,
+        sessions: pipe.knownSessions().length,
+        counters: pipe.counters,
+      })
+    }
+    if (url.pathname === "/__ogr/mask" && req.method === "POST") {
+      const raw = await readBody(req)
+      let body: { value?: unknown; session?: string }
+      try {
+        body = JSON.parse(raw.toString("utf8") || "{}") as typeof body
+      } catch {
+        return reply(400, { error: "bad_json" })
+      }
+      // `maskKnown`, never `mask`: this side must not MINT. A hook sees the
+      // harness's own transcript, which is a COPY of what the provider was
+      // sent — minting from it would allocate a second token for a value the
+      // request half already named, and the two would never restore alike.
+      const session = body.session ?? pipe.knownSessions()[0] ?? "process"
+      const masked = pipe.redactor.maskKnown(session, body.value ?? null)
+      return reply(200, {
+        value: masked.value,
+        changed: masked.changed,
+        ...(pipe.report(session) ? { redaction: pipe.report(session) } : {}),
+      })
+    }
+    return reply(404, { error: "not_found" })
+  }
+
+  await new Promise<void>((resolve) => server.listen(opts.port ?? 0, opts.host ?? "127.0.0.1", resolve))
+  const address = server.address()
+  const port = typeof address === "object" && address ? address.port : 0
+
+  let idleTimer: NodeJS.Timeout | undefined
+  if (opts.idleMs && opts.idleMs > 0) {
+    idleTimer = setInterval(() => {
+      if (nowMs() - lastActivity > opts.idleMs!) {
+        log.info("[ogr-local] idle — shutting down")
+        void close()
+      }
+    }, Math.min(opts.idleMs, 30_000))
+    idleTimer.unref?.()
+  }
+
+  const close = async (): Promise<void> => {
+    if (idleTimer) clearInterval(idleTimer)
+    await new Promise<void>((resolve) => server.close(() => resolve()))
+  }
+
+  return { url: `http://127.0.0.1:${port}`, port, pipe, close }
+}
+
+export type { Server }

--- a/integrations/agent/ogr-local/tests/proxy.spec.mjs
+++ b/integrations/agent/ogr-local/tests/proxy.spec.mjs
@@ -1,0 +1,279 @@
+/**
+ * The proxy, driven end to end against a stand-in provider.
+ *
+ * The claim under test is the one the whole design rests on: **the provider
+ * is given a token and the harness is given back the value**. Everything
+ * else here guards a way that could stop being true without anything
+ * failing — a passthrough that quietly rewrote a non-model call, an SSE
+ * reply whose tool arguments came back still tokenised, an upstream the
+ * path could name freely.
+ */
+import { test } from "node:test"
+import assert from "node:assert/strict"
+import { createServer } from "node:http"
+import { mkdtempSync, rmSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+
+import { LocalRedactor } from "@openguardrails/local-redaction"
+import { startProxy, upstreamFor, baseUrlFor } from "../dist/index.js"
+
+const KEY = "sk-proj-abcdefghijklmnopqrstuvwx"
+
+const RULESET = {
+  id: "rs_proxytest",
+  generated_at: "2026-08-29T00:00:00Z",
+  family: "secrets",
+  dialect: "ogr-re-1",
+  rules: [{
+    id: "entity_api_key",
+    category: "secrets",
+    severity: "critical",
+    tier: "strong",
+    flags: "",
+    patterns: [{ id: "openai_project", source: "sk-proj-[A-Za-z0-9_-]{20,}" }],
+    examples: { match: [KEY], nomatch: ["sk-proj-short"] },
+  }],
+}
+
+/** A provider that records what it was sent and replies as told. */
+async function startProvider(reply) {
+  const seen = []
+  const server = createServer((req, res) => {
+    let body = ""
+    req.on("data", (c) => { body += c })
+    req.on("end", () => {
+      seen.push({ url: req.url, body, headers: req.headers })
+      reply(req, res, body)
+    })
+  })
+  await new Promise((r) => server.listen(0, "127.0.0.1", r))
+  return { seen, port: server.address().port, close: () => new Promise((r) => server.close(r)) }
+}
+
+async function withProxy(reply, body) {
+  const dir = mkdtempSync(join(tmpdir(), "ogr-local-"))
+  const provider = await startProvider(reply)
+  const redactor = new LocalRedactor({
+    // The ruleset comes from a file rather than a served route: this suite
+    // is about the PROXY, and a fetch in the middle of it would make a
+    // masking failure and a rules-outage failure look alike.
+    source: () => null,
+    cachePath: join(dir, "rules.json"),
+    log: { info: () => {}, warn: () => {} },
+  })
+  // Seed the cache, then start: exactly the "warm install" path.
+  const { writeCachedRuleset } = await import("@openguardrails/local-redaction")
+  writeCachedRuleset(join(dir, "rules.json"), RULESET)
+  await redactor.start()
+  redactor.fallbackActive = true
+
+  const proxy = await startProxy({
+    redactor,
+    hosts: ["127.0.0.1"],
+    log: { info: () => {}, warn: () => {} },
+  })
+  try {
+    return await body({ proxy, provider, redactor })
+  } finally {
+    await proxy.close()
+    await provider.close()
+    rmSync(dir, { recursive: true, force: true })
+  }
+}
+
+const jsonReply = (payload) => (_req, res) => {
+  const bytes = Buffer.from(JSON.stringify(payload))
+  res.writeHead(200, { "content-type": "application/json", "content-length": String(bytes.length) })
+  res.end(bytes)
+}
+
+test("the provider gets a token; the harness gets the value back", async () => {
+  await withProxy(
+    jsonReply({
+      id: "msg_1",
+      content: [{ type: "tool_use", id: "t1", name: "deploy", input: { token: "${OGR_SECRET_1}" } }],
+    }),
+    async ({ proxy, provider }) => {
+      const res = await fetch(`${proxy.url}/http/127.0.0.1:${provider.port}/v1/messages`, {
+        method: "POST",
+        headers: { "content-type": "application/json", authorization: "Bearer sk-ant-user-key" },
+        body: JSON.stringify({ model: "claude", system: `use ${KEY}`, messages: [{ role: "user", content: "deploy" }] }),
+      })
+      const back = await res.json()
+
+      // What the provider saw
+      assert.equal(provider.seen[0].body.includes(KEY), false, "the credential reached the provider")
+      assert.match(provider.seen[0].body, /\$\{OGR_SECRET_1\}/)
+      // What the harness got back — the real value, in the tool's arguments
+      assert.equal(back.content[0].input.token, KEY)
+    },
+  )
+})
+
+test("the harness's own credential is forwarded untouched — the proxy is not an auth boundary", async () => {
+  await withProxy(jsonReply({ ok: true }), async ({ proxy, provider }) => {
+    await fetch(`${proxy.url}/http/127.0.0.1:${provider.port}/v1/messages`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        authorization: "Bearer sk-ant-user-key",
+        "x-api-key": "another-form-of-the-same-thing",
+        "anthropic-version": "2023-06-01",
+      },
+      body: JSON.stringify({ model: "claude", messages: [{ role: "user", content: "hi" }] }),
+    })
+    const sent = provider.seen[0].headers
+    // The proxy holds no credential and mints none: whatever the harness
+    // authenticated with reaches the provider byte for byte, and a
+    // provider-specific header it has never heard of survives too.
+    assert.equal(sent.authorization, "Bearer sk-ant-user-key")
+    assert.equal(sent["x-api-key"], "another-form-of-the-same-thing")
+    assert.equal(sent["anthropic-version"], "2023-06-01")
+    // ...and the hop-by-hop ones do not.
+    assert.equal(sent.host, `127.0.0.1:${provider.port}`, "the Host header must name the UPSTREAM, not the proxy")
+    assert.equal("connection" in sent && sent.connection === "keep-alive, keep-alive", false)
+  })
+})
+
+test("a non-model call is passed through byte for byte", async () => {
+  await withProxy(jsonReply({ data: [] }), async ({ proxy, provider }) => {
+    const body = JSON.stringify({ anything: `not a model call, but it mentions ${KEY}` })
+    await fetch(`${proxy.url}/http/127.0.0.1:${provider.port}/v1/models`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body,
+    })
+    // ⚠️ The harness talks to its provider about more than completions. A
+    // proxy that masked a token-count or a file upload would break the
+    // harness while protecting nothing — the value is not going to a model.
+    assert.equal(provider.seen[0].body, body)
+  })
+})
+
+test("a streamed reply comes back with its tool arguments restored", async () => {
+  const sse = (_req, res) => {
+    res.writeHead(200, { "content-type": "text/event-stream" })
+    res.write('event: content_block_start\ndata: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"t1","name":"deploy","input":{}}}\n\n')
+    res.write('event: content_block_delta\ndata: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\\"token\\":\\"${OGR_SECRET_1}\\"}"}}\n\n')
+    res.write('event: message_stop\ndata: {"type":"message_stop"}\n\n')
+    res.end()
+  }
+  await withProxy(sse, async ({ proxy, provider }) => {
+    const res = await fetch(`${proxy.url}/http/127.0.0.1:${provider.port}/v1/messages`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ model: "claude", system: `use ${KEY}`, messages: [{ role: "user", content: "go" }], stream: true }),
+    })
+    const text = await res.text()
+    assert.equal(provider.seen[0].body.includes(KEY), false)
+    assert.equal(text.includes(KEY), true, "the streamed tool call reached the harness still tokenised")
+  })
+})
+
+test("the path may only name a model API host", async () => {
+  await withProxy(jsonReply({ ok: true }), async ({ proxy }) => {
+    const res = await fetch(`${proxy.url}/https/evil.example.com/v1/messages`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ model: "x", messages: [] }),
+    })
+    // Without this the daemon would be a general-purpose forwarder any
+    // process on the machine could reach.
+    assert.equal(res.status, 403)
+  })
+})
+
+test("/__ogr/mask tokenises a hook's own event, and never mints", async () => {
+  await withProxy(jsonReply({ ok: true }), async ({ proxy, provider }) => {
+    await fetch(`${proxy.url}/http/127.0.0.1:${provider.port}/v1/messages`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ model: "claude", system: `use ${KEY}`, messages: [{ role: "user", content: "go" }] }),
+    })
+    const res = await fetch(`${proxy.url}/__ogr/mask`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ value: { text: `the key is ${KEY}`, other: "sk-proj-neverseenbeforeaaaaaaaa" } }),
+    })
+    const { value, redaction } = await res.json()
+    assert.equal(value.text, "the key is ${OGR_SECRET_1}", "a value the request half already named must reuse its token")
+    assert.equal(value.other, "sk-proj-neverseenbeforeaaaaaaaa",
+      "the control surface must not MINT — a second token for a value the provider never saw restores to nothing")
+    assert.equal(redaction.ruleset, RULESET.id)
+  })
+})
+
+test("there is no /__ogr/restore", async () => {
+  await withProxy(jsonReply({ ok: true }), async ({ proxy }) => {
+    const res = await fetch(`${proxy.url}/__ogr/restore`, { method: "POST", body: "{}" })
+    // A loopback route that turned tokens back into secrets would hand every
+    // process on this machine the plaintext of the session.
+    assert.equal(res.status, 404)
+  })
+})
+
+test("the upstream is read from the path, and the base URL is derivable", () => {
+  const at = (p) => upstreamFor(new URL(`http://127.0.0.1:8787${p}`), null)
+  assert.deepEqual(at("/https/api.anthropic.com/v1/messages"),
+    { base: "https://api.anthropic.com", path: "/v1/messages", host: "api.anthropic.com", hostname: "api.anthropic.com" })
+  assert.deepEqual(at("/https/chatgpt.com/backend-api/codex/responses"),
+    { base: "https://chatgpt.com", path: "/backend-api/codex/responses", host: "chatgpt.com", hostname: "chatgpt.com" })
+  assert.equal(at("/v1/messages"), null)
+  assert.equal(upstreamFor(new URL("http://127.0.0.1:8787/v1/messages"), "https://api.anthropic.com").base,
+    "https://api.anthropic.com")
+  assert.equal(baseUrlFor("https://api.anthropic.com", 8787), "http://127.0.0.1:8787/https/api.anthropic.com")
+  assert.equal(baseUrlFor("https://chatgpt.com/backend-api/codex", 8787),
+    "http://127.0.0.1:8787/https/chatgpt.com/backend-api/codex")
+})
+
+test("a decompressed reply does not keep the provider's content-encoding", async () => {
+  const { gzipSync } = await import("node:zlib")
+  const gz = (_req, res) => {
+    const body = gzipSync(JSON.stringify({ content: [{ type: "tool_use", id: "t1", name: "d", input: { token: "${OGR_SECRET_1}" } }] }))
+    res.writeHead(200, { "content-type": "application/json", "content-encoding": "gzip", "content-length": String(body.length) })
+    res.end(body)
+  }
+  await withProxy(gz, async ({ proxy, provider }) => {
+    const res = await fetch(`${proxy.url}/http/127.0.0.1:${provider.port}/v1/messages`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ model: "claude", system: `use ${KEY}`, messages: [{ role: "user", content: "go" }] }),
+    })
+    // `fetch` decompressed it, so the bytes we forward are plain. Keeping the
+    // provider's header would hand the harness a body it cannot decode.
+    assert.equal(res.headers.get("content-encoding"), null)
+    const back = await res.json()
+    assert.equal(back.content[0].input.token, KEY)
+  })
+})
+
+test("a client that hangs up mid-stream does not take the daemon down", async () => {
+  // The provider keeps the stream open; the TEST is what releases it, so the
+  // fixture can tear down even though the scenario is "nobody ended this".
+  const open = []
+  const slow = (_req, res) => {
+    open.push(res)
+    res.writeHead(200, { "content-type": "text/event-stream" })
+    res.write('event: x\ndata: {"a":1}\n\n')
+  }
+  await withProxy(slow, async ({ proxy, provider }) => {
+    const controller = new AbortController()
+    const started = fetch(`${proxy.url}/http/127.0.0.1:${provider.port}/v1/messages`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ model: "claude", messages: [{ role: "user", content: "go" }], stream: true }),
+      signal: controller.signal,
+    })
+    const res = await started
+    await res.body.getReader().read()
+    controller.abort()
+    await new Promise((r) => setTimeout(r, 120))
+    // Still serving. A daemon outlives the request that killed it, and an
+    // unhandled socket `error` would have taken the harness's model access
+    // down with the proxy.
+    const status = await fetch(`${proxy.url}/__ogr/status`)
+    assert.equal(status.ok, true)
+    for (const res of open) res.end()
+  })
+})

--- a/integrations/agent/ogr-local/tsconfig.json
+++ b/integrations/agent/ogr-local/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "target": "ES2022", "module": "NodeNext", "moduleResolution": "NodeNext",
+    "lib": ["ES2022"], "declaration": true, "declarationMap": true, "sourceMap": true,
+    "strict": true, "noUncheckedIndexedAccess": true, "esModuleInterop": true,
+    "skipLibCheck": true, "forceConsistentCasingInFileNames": true, "verbatimModuleSyntax": true,
+    "outDir": "./dist", "rootDir": "./src", "types": ["node"]
+  },
+  "include": ["src"]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "license": "Apache-2.0",
       "workspaces": [
         "integrations/agent/local-redaction",
+        "integrations/agent/ogr-local",
         "integrations/agent/dsh",
         "integrations/agent/opencode",
         "integrations/agent/openclaw"
@@ -42,8 +43,11 @@
     },
     "integrations/agent/dsh": {
       "name": "@openguardrails/dsh",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "license": "Apache-2.0",
+      "dependencies": {
+        "@openguardrails/local-redaction": "^0.1.0"
+      },
       "devDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
         "@deepseek-ai/dsh-agent": "0.1.0-rc.6",
@@ -170,6 +174,21 @@
       "name": "@openguardrails/local-redaction",
       "version": "0.1.0",
       "license": "Apache-2.0",
+      "devDependencies": {
+        "@types/node": "^22",
+        "typescript": "^5.7.0"
+      }
+    },
+    "integrations/agent/ogr-local": {
+      "name": "@openguardrails/ogr-local",
+      "version": "0.1.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@openguardrails/local-redaction": "^0.1.0"
+      },
+      "bin": {
+        "ogr-local": "dist/cli.js"
+      },
       "devDependencies": {
         "@types/node": "^22",
         "typescript": "^5.7.0"
@@ -963,6 +982,10 @@
     },
     "node_modules/@openguardrails/local-redaction": {
       "resolved": "integrations/agent/local-redaction",
+      "link": true
+    },
+    "node_modules/@openguardrails/ogr-local": {
+      "resolved": "integrations/agent/ogr-local",
       "link": true
     },
     "node_modules/@openguardrails/opencode-auto-mode": {

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "license": "Apache-2.0",
   "workspaces": [
     "integrations/agent/local-redaction",
+    "integrations/agent/ogr-local",
     "integrations/agent/dsh",
     "integrations/agent/opencode",
     "integrations/agent/openclaw"


### PR DESCRIPTION
dsh, Claude Code and Codex join hermes, opencode and openclaw. The question that decides *how* is not the harness but one property of it: **can code run inside the agent's own process?**

| | mask | version |
|---|---|---|
| hermes · opencode · openclaw · **dsh** | in-process `fetch` interceptor | 2.0 · 0.4 · 0.4 · **0.4** |
| **Claude Code** · **Codex** | **`ogr-local`** loopback proxy (new package) | **2.0** · **2.0** |

### dsh has exactly one seam, and it is forced

A loop-built `GenerateOptions` is frozen and `dsh-agent-loop`'s invariant asserts `JSON.stringify(options.messages) === session.deriveMessages()`, so the `llm/stream` waterfall may *observe* a request and never rewrite one. `exec.arguments` is `readonly` and `PreToolDecision` has no replace arm, so there is no restore hook either — and none is needed, because the interceptor restores the reply a layer below dsh.

Being the first thing on the host to see a step, its plugin **mints on the event**; the interceptor meets the same values already mapped moments later and reuses the tokens, so the provider and the runtime are given identical text.

### Claude Code and Codex cannot host a plugin at all

Their hooks are separate processes and Codex's host is Rust. `ogr-local` puts the same masking behind a loopback proxy the provider base URL points at, with **the upstream carried in the path** so one daemon on one port serves both — the port must be fixed because both harnesses resolve that URL statically at startup (`settings.json` `env` / `config.toml`).

Their hooks report from the harness's own transcript, which is the **cleartext** copy (the proxy restored the reply on the way back), so they seal their events through `/__ogr/mask` — `maskKnown`, which may reuse a token but never allocate one that would name nothing.

⚠️ **The proxy is the strictly weaker position**, and three READMEs say so: a second process that must be running, whose failure is not "nothing is masked" but "the harness cannot reach its provider". It holds no credential, refuses any upstream outside the model-host allowlist (a path-addressed proxy without one is an *open* proxy), refuses to start without an API key, and offers **no `/__ogr/restore`** — a loopback route turning tokens back into secrets would hand every local process the plaintext of the session.

### Two things that fail silently, now pinned by tests

**Carrying a session key.** `als.run(k, () => next())` scopes the *construction* of the downstream iterable; the generator body runs when the consumer pulls, after that scope exits. Measured:

```
als.run(k, () => next())           → the adapter's fetch sees `undefined`
await als.run(k, () => it.next())  → A sees A, B sees B
```

`undefined` collapses every conversation in a `dsh web` process onto one map key, so a token minted in one answers a restore in another — the wrong secret spliced into a tool call, nothing thrown. `dsh/tests/redaction.spec.mjs` *executes* the naive form and asserts it loses the key.

**Claiming coverage.** Masking an event while the provider copy went out in the clear blinds the runtime's own `secrets` detector, the one witness left. Every integration gates event masking on something provably on the path, and with no proxy running a hook's event goes as built carrying no `redaction` at all.

### Also

- `chatgpt.com` joins the model-host list (Codex's ChatGPT-login backend).
- The proxy drops `content-encoding` after `fetch` decompresses, and survives a client hanging up mid-stream — a daemon outlives the request that kills it.
- `package-lock.json` gains only the new workspace. It is stale at `main` (it carries `@opencode-ai/*` and `@openclaw/*` entries no `package.json` declares, so any `npm install` prunes ~340 of them); that is left alone rather than folded into a feature merge.

### Tests

local-redaction 70 · ogr-local 10 · dsh 49 · opencode 29 · openclaw 28; claude-code and codex smoke suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015RTdCro76kgUVcAY9x5TQM